### PR TITLE
Add momentum_dca strategy with 20% coverage enforcement

### DIFF
--- a/tests/test_momentum_dca.py
+++ b/tests/test_momentum_dca.py
@@ -1,0 +1,364 @@
+"""
+Tests for MomentumDcaStrategy
+"""
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from trading_system.strategies.momentum_dca_strategy import MomentumDcaStrategy
+
+
+@pytest.fixture
+def strategy():
+    """Create a MomentumDcaStrategy instance"""
+    return MomentumDcaStrategy(
+        symbols=['BTC', 'SPY'],
+        coverage_threshold=0.20,
+        stop_offset_pct=0.015,
+        proximity_pct=0.0075
+    )
+
+
+def _make_position(symbol, quantity, price):
+    return {
+        'symbol': symbol,
+        'quantity': quantity,
+        'current_price': price,
+        'equity': quantity * price,
+    }
+
+
+def _make_sell_order(symbol, quantity, limit_price=None, stop_price=None,
+                     order_type='Limit', trigger='immediate'):
+    return {
+        'symbol': symbol,
+        'side': 'SELL',
+        'order_type': order_type,
+        'trigger': trigger,
+        'quantity': quantity,
+        'limit_price': limit_price,
+        'stop_price': stop_price,
+    }
+
+
+class TestCoverageCalculation:
+    """Test coverage % calculation"""
+
+    def test_fully_covered(self, strategy):
+        """Position with >= 20% sell orders → COVERED"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [_make_sell_order('SPY', 25, limit_price=460.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVERED'
+        assert signal['order'] is None
+
+    def test_exactly_at_threshold(self, strategy):
+        """Position with exactly 20% coverage → COVERED"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [_make_sell_order('SPY', 20, limit_price=460.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVERED'
+
+    def test_under_covered_no_existing_orders(self, strategy):
+        """Position with 0% coverage, no existing orders → COVER_GAP"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = []
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['action'] == 'stop_limit_sell'
+        assert signal['order']['quantity'] == 20  # 20% of 100
+
+    def test_partial_coverage(self, strategy):
+        """Position with 10% coverage → gap of 10%"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [_make_sell_order('SPY', 10, limit_price=460.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['order'] is not None
+        assert signal['order']['quantity'] == 10  # need 20 - have 10
+
+    def test_multiple_order_types_count(self, strategy):
+        """All sell order types count toward coverage"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [
+            _make_sell_order('SPY', 5, limit_price=460.0),
+            _make_sell_order('SPY', 5, stop_price=440.0,
+                             order_type='Stop Loss', trigger='stop'),
+            _make_sell_order('SPY', 5, limit_price=438.0, stop_price=440.0,
+                             order_type='Stop Limit', trigger='stop'),
+            _make_sell_order('SPY', 5, limit_price=435.0),
+        ]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        # 5+5+5+5 = 20 shares = 20% → COVERED
+        assert signal['signal'] == 'COVERED'
+
+    def test_buy_orders_ignored(self, strategy):
+        """BUY orders should not count toward coverage"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [
+            {'symbol': 'SPY', 'side': 'BUY', 'order_type': 'Limit',
+             'trigger': 'immediate', 'quantity': 50, 'limit_price': 440.0,
+             'stop_price': None},
+        ]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['quantity'] == 20
+
+    def test_other_symbol_orders_ignored(self, strategy):
+        """Orders for different symbol should not count"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [_make_sell_order('AAPL', 50, limit_price=180.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVER_GAP'
+
+
+class TestGapQuantity:
+    """Test gap quantity calculation"""
+
+    def test_gap_from_zero(self, strategy):
+        """No orders → gap is 20% of position"""
+        position = _make_position('SPY', 200, 450.0)
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, [])
+
+        assert signal['order']['quantity'] == 40  # 20% of 200
+
+    def test_gap_from_partial(self, strategy):
+        """Partial coverage → gap fills to 20%"""
+        position = _make_position('SPY', 200, 450.0)
+        orders = [_make_sell_order('SPY', 15, limit_price=460.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['order']['quantity'] == 25  # 40 - 15
+
+    def test_btc_fractional_quantity(self, strategy):
+        """BTC should use 4 decimal places"""
+        position = _make_position('BTC', 0.5, 100000.0)
+        metrics = {'current_price': 100000.0}
+
+        signal = strategy.analyze_symbol('BTC', metrics, position, [])
+
+        assert signal['order']['quantity'] == 0.1  # 20% of 0.5
+        # Verify it's rounded to 4 decimals
+        assert round(signal['order']['quantity'], 4) == signal['order']['quantity']
+
+    def test_stock_whole_shares(self, strategy):
+        """Stock quantities should be whole numbers"""
+        position = _make_position('SPY', 7, 450.0)
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, [])
+
+        assert signal['order']['quantity'] == 1  # int(20% of 7) = int(1.4) = 1
+        assert isinstance(signal['order']['quantity'], int)
+
+
+class TestStopLimitPricing:
+    """Test -1.5% stop-limit pricing"""
+
+    def test_stop_price_at_negative_1_5_pct(self, strategy):
+        """Stop price should be current_price * 0.985"""
+        position = _make_position('SPY', 100, 450.0)
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, [])
+
+        expected_stop = round(450.0 * 0.985, 2)
+        assert signal['order']['stop_price'] == expected_stop
+        assert signal['order']['limit_price'] == expected_stop
+
+    def test_stop_equals_limit(self, strategy):
+        """Stop and limit should be the same price"""
+        position = _make_position('BTC', 1.0, 100000.0)
+        metrics = {'current_price': 100000.0}
+
+        signal = strategy.analyze_symbol('BTC', metrics, position, [])
+
+        assert signal['order']['stop_price'] == signal['order']['limit_price']
+
+
+class TestPriceProximity:
+    """Test the 0.75% proximity check and resubmit logic"""
+
+    def test_within_proximity_resubmits(self, strategy):
+        """Price within 0.75% of existing order → RESUBMIT"""
+        position = _make_position('SPY', 100, 450.0)
+        # Existing order at 452.0, current price 450.0
+        # Distance: |450 - 452| / 452 = 0.44% < 0.75%
+        orders = [_make_sell_order('SPY', 10, limit_price=452.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['action'] == 'limit_sell'
+        assert signal['order']['price'] == 452.0  # original order price
+
+    def test_outside_proximity_new_stop_limit(self, strategy):
+        """Price beyond 0.75% of existing order → COVER_GAP"""
+        position = _make_position('SPY', 100, 450.0)
+        # Existing order at 500.0, current price 450.0
+        # Distance: |450 - 500| / 500 = 10% > 0.75%
+        orders = [_make_sell_order('SPY', 10, limit_price=500.0)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['action'] == 'stop_limit_sell'
+
+    def test_resubmit_uses_original_price(self, strategy):
+        """RESUBMIT should use the original order price, not current"""
+        position = _make_position('SPY', 100, 448.0)
+        orders = [_make_sell_order('SPY', 10, limit_price=450.0)]
+        metrics = {'current_price': 448.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['price'] == 450.0
+        assert signal['order']['current_price'] == 448.0
+
+    def test_proximity_with_stop_price_order(self, strategy):
+        """Proximity check works with stop-price orders too"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [_make_sell_order('SPY', 10, stop_price=449.0,
+                                   order_type='Stop Loss', trigger='stop')]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        # |450 - 449| / 449 = 0.22% < 0.75% → RESUBMIT
+        assert signal['signal'] == 'RESUBMIT'
+
+    def test_proximity_boundary_exact(self, strategy):
+        """Price at exactly 0.75% boundary"""
+        position = _make_position('SPY', 100, 450.0)
+        # 0.75% of 450 = 3.375, so order at 450 + 3.375 = 453.375
+        # Distance: |450 - 453.375| / 453.375 = 0.00744... which is < 0.0075
+        orders = [_make_sell_order('SPY', 10, limit_price=453.375)]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'RESUBMIT'
+
+    def test_nearest_order_selected(self, strategy):
+        """When multiple orders exist, nearest one is used for proximity"""
+        position = _make_position('SPY', 100, 450.0)
+        orders = [
+            _make_sell_order('SPY', 5, limit_price=500.0),  # far
+            _make_sell_order('SPY', 5, limit_price=451.0),  # near
+        ]
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, orders)
+
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['price'] == 451.0
+
+
+class TestEdgeCases:
+    """Test edge cases"""
+
+    def test_no_position(self, strategy):
+        """No position → NO_POSITION"""
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, None, [])
+
+        assert signal['signal'] == 'NO_POSITION'
+
+    def test_zero_quantity_position(self, strategy):
+        """Position with 0 quantity → NO_POSITION"""
+        position = _make_position('SPY', 0, 450.0)
+        metrics = {'current_price': 450.0}
+
+        signal = strategy.analyze_symbol('SPY', metrics, position, [])
+
+        assert signal['signal'] == 'NO_POSITION'
+
+    def test_no_price_data(self, strategy):
+        """No current_price in metrics → NO_DATA"""
+        position = _make_position('SPY', 100, 450.0)
+
+        signal = strategy.analyze_symbol('SPY', {}, position, [])
+
+        assert signal['signal'] == 'NO_DATA'
+
+    def test_format_signal_cover_gap(self, strategy):
+        """format_signal produces output for COVER_GAP"""
+        signal = {
+            'signal': 'COVER_GAP',
+            'reason': 'test reason',
+            'order': {
+                'action': 'stop_limit_sell',
+                'symbol': 'SPY',
+                'quantity': 20,
+                'stop_price': 443.25,
+                'limit_price': 443.25,
+                'current_price': 450.0,
+            }
+        }
+
+        output = strategy.format_signal('SPY', signal)
+
+        assert 'COVER_GAP' in output
+        assert 'Stop Price' in output
+        assert '443.25' in output
+
+    def test_format_signal_resubmit(self, strategy):
+        """format_signal produces output for RESUBMIT"""
+        signal = {
+            'signal': 'RESUBMIT',
+            'reason': 'test reason',
+            'order': {
+                'action': 'limit_sell',
+                'symbol': 'SPY',
+                'quantity': 10,
+                'price': 452.0,
+                'current_price': 450.0,
+            }
+        }
+
+        output = strategy.format_signal('SPY', signal)
+
+        assert 'RESUBMIT' in output
+        assert 'Limit Price' in output
+
+    def test_format_signal_covered(self, strategy):
+        """format_signal produces output for COVERED"""
+        signal = {
+            'signal': 'COVERED',
+            'reason': 'fully covered',
+            'order': None,
+        }
+
+        output = strategy.format_signal('SPY', signal)
+
+        assert 'COVERED' in output

--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from trading_system.data_providers.twelve_data import TwelveDataProvider  # noqa: E402
 from trading_system.utils.metrics import MetricsCalculator  # noqa: E402
 from trading_system.strategies.breakout_strategy import BreakoutStrategy  # noqa: E402
+from trading_system.strategies.momentum_dca_strategy import MomentumDcaStrategy  # noqa: E402
 from trading_system.state.state_manager import StateManager  # noqa: E402
 from utils.safe_cash_bot import SafeCashBot  # noqa: E402
 
@@ -23,7 +24,8 @@ class TradingSystem:
     """Main trading system orchestrator"""
 
     def __init__(self, twelve_data_api_key: str, symbols: List[str],
-                 position_size_pct: float = 0.25, dry_run: bool = True):
+                 position_size_pct: float = 0.25, dry_run: bool = True,
+                 strategy_name: str = 'momentum_dca'):
         """
         Initialize trading system
 
@@ -32,20 +34,28 @@ class TradingSystem:
             symbols: List of symbols to trade
             position_size_pct: Position size as percentage of portfolio
             dry_run: If True, simulates orders without execution
+            strategy_name: Strategy to use ('momentum_dca' or 'breakout')
         """
         self.symbols = symbols
         self.dry_run = dry_run
+        self.strategy_name = strategy_name
 
         # Initialize components
         self.data_provider = TwelveDataProvider(twelve_data_api_key)
         self.metrics_calculator = MetricsCalculator()
-        self.strategy = BreakoutStrategy(symbols, position_size_pct)
         self.state_manager = StateManager('trading_state.json')
         self.trading_bot = SafeCashBot()
+
+        # Select strategy
+        if strategy_name == 'momentum_dca':
+            self.strategy = MomentumDcaStrategy(symbols)
+        else:
+            self.strategy = BreakoutStrategy(symbols, position_size_pct)
 
         print(f"\n{'='*70}")
         print("TRADING SYSTEM INITIALIZED")
         print(f"{'='*70}")
+        print(f"Strategy: {strategy_name}")
         print(f"Symbols: {', '.join(symbols)}")
         print(f"Mode: {'DRY RUN (Simulation)' if dry_run else 'LIVE TRADING'}")
         print(f"Position Size: {position_size_pct * 100}% per symbol")
@@ -102,13 +112,15 @@ class TradingSystem:
 
         return metrics
 
-    def execute_strategy(self, symbol: str, metrics: Dict) -> Dict:
+    def execute_strategy(self, symbol: str, metrics: Dict,
+                         open_orders: List[Dict] = None) -> Dict:
         """
         Execute strategy for a symbol
 
         Args:
             symbol: Stock symbol
             metrics: Calculated metrics
+            open_orders: Open orders (used by momentum_dca strategy)
 
         Returns:
             Signal data
@@ -121,7 +133,12 @@ class TradingSystem:
         )
 
         # Analyze and generate signal
-        signal = self.strategy.analyze_symbol(symbol, metrics, current_position)
+        if self.strategy_name == 'momentum_dca':
+            signal = self.strategy.analyze_symbol(
+                symbol, metrics, current_position, open_orders
+            )
+        else:
+            signal = self.strategy.analyze_symbol(symbol, metrics, current_position)
 
         return signal
 
@@ -145,9 +162,12 @@ class TradingSystem:
 
         if order['action'] == 'buy':
             self._execute_buy_order(symbol, order)
-
         elif order['action'] == 'sell':
             self._execute_sell_order(symbol, order)
+        elif order['action'] == 'stop_limit_sell':
+            self._execute_stop_limit_sell_order(symbol, order)
+        elif order['action'] == 'limit_sell':
+            self._execute_limit_sell_resubmit(symbol, order)
 
     def _execute_buy_order(self, symbol: str, order: Dict):
         """Execute buy order"""
@@ -230,6 +250,75 @@ class TradingSystem:
                 )
                 print(f"Order placed: {order_id}")
 
+    def _execute_stop_limit_sell_order(self, symbol: str, order: Dict):
+        """Execute stop-limit sell order for gap coverage"""
+        quantity = order['quantity']
+        stop_price = order['stop_price']
+        limit_price = order['limit_price']
+
+        # Queue order in state
+        order_details = {
+            'quantity': quantity,
+            'stop_price': stop_price,
+            'limit_price': limit_price,
+            'trigger': 'coverage_gap',
+            'order_type': 'stop_limit_sell'
+        }
+        self.state_manager.queue_sell_order(symbol, order_details)
+
+        print(f"\n{'='*70}")
+        print(f"EXECUTING STOP-LIMIT SELL: {symbol}")
+        print(f"{'='*70}")
+        print(f"Quantity: {quantity}")
+        print(f"Stop Price: ${stop_price:,.2f}")
+        print(f"Limit Price: ${limit_price:,.2f}")
+        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE'}")
+        print(f"{'='*70}\n")
+
+        if not self.dry_run:
+            result = self.trading_bot.place_stop_limit_sell_order(
+                symbol, quantity, stop_price, limit_price, dry_run=False
+            )
+            if result:
+                order_id = result.get('id', 'unknown')
+                self.state_manager.update_order_status(
+                    symbol, 'sell', 'placed', order_id
+                )
+                print(f"Order placed: {order_id}")
+
+    def _execute_limit_sell_resubmit(self, symbol: str, order: Dict):
+        """Execute limit sell resubmit at original order price"""
+        quantity = order['quantity']
+        price = order['price']
+
+        # Queue order in state
+        order_details = {
+            'quantity': quantity,
+            'price': price,
+            'trigger': 'resubmit',
+            'order_type': 'limit_sell'
+        }
+        self.state_manager.queue_sell_order(symbol, order_details)
+
+        print(f"\n{'='*70}")
+        print(f"RESUBMITTING LIMIT SELL: {symbol}")
+        print(f"{'='*70}")
+        print(f"Quantity: {quantity}")
+        print(f"Limit Price: ${price:,.2f} (original order price)")
+        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE'}")
+        print(f"{'='*70}\n")
+
+        if not self.dry_run:
+            result = self.trading_bot.place_sell_order(
+                symbol, quantity, price, dry_run=False
+            )
+            if result:
+                order_id = result.get('id', 'unknown')
+                self.state_manager.update_order_status(
+                    symbol, 'sell', 'placed', order_id
+                )
+                print(f"Order placed: {order_id}")
+
     def print_portfolio_allocation(self):
         """Print current portfolio allocation summary"""
         print(f"\n{'='*70}")
@@ -293,6 +382,11 @@ class TradingSystem:
         # Print initial portfolio allocation
         self.print_portfolio_allocation()
 
+        # Fetch open orders once (used by momentum_dca)
+        open_orders = []
+        if self.strategy_name == 'momentum_dca':
+            open_orders = self.trading_bot.get_open_orders()
+
         for symbol in self.symbols:
             print(f"\n{'#'*70}")
             print(f"Processing {symbol}")
@@ -307,7 +401,7 @@ class TradingSystem:
                 print(self.metrics_calculator.format_metrics(symbol, metrics))
 
                 # 3. Execute strategy
-                signal = self.execute_strategy(symbol, metrics)
+                signal = self.execute_strategy(symbol, metrics, open_orders)
 
                 # 4. Process signal
                 self.process_signal(symbol, signal)
@@ -359,7 +453,7 @@ def main():
     load_dotenv()
 
     # Parse arguments
-    parser = argparse.ArgumentParser(description='30-Day Breakout Trading System')
+    parser = argparse.ArgumentParser(description='Trading System')
     parser.add_argument(
         '--live',
         action='store_true',
@@ -375,6 +469,13 @@ def main():
         type=int,
         default=5,
         help='Minutes between runs in continuous mode (default: 5)'
+    )
+    parser.add_argument(
+        '--strategy',
+        type=str,
+        choices=['momentum_dca', 'breakout'],
+        default='momentum_dca',
+        help='Trading strategy to use (default: momentum_dca)'
     )
 
     args = parser.parse_args()
@@ -404,7 +505,8 @@ def main():
         twelve_data_api_key=api_key,
         symbols=symbols,
         position_size_pct=0.25,
-        dry_run=not args.live
+        dry_run=not args.live,
+        strategy_name=args.strategy
     )
 
     # Run system

--- a/trading_system/strategies/momentum_dca_strategy.py
+++ b/trading_system/strategies/momentum_dca_strategy.py
@@ -1,0 +1,213 @@
+"""
+Momentum DCA Strategy
+Ensures at least 20% of each position is covered by sell orders at all times.
+If coverage is below threshold:
+  - Price within 0.75% of existing order → resubmit at original price
+  - Price moved >0.75% → place stop-limit at -1.5% below current price
+"""
+
+from typing import Dict, Optional, List
+
+
+class MomentumDcaStrategy:
+    """
+    Momentum Dollar-Cost Averaging Strategy
+
+    Monitors open sell orders against positions and maintains a minimum
+    coverage threshold. Places protective orders to fill gaps.
+    """
+
+    def __init__(self, symbols: List[str], coverage_threshold: float = 0.20,
+                 stop_offset_pct: float = 0.015, proximity_pct: float = 0.0075):
+        """
+        Args:
+            symbols: List of symbols to trade
+            coverage_threshold: Minimum coverage ratio (default 20%)
+            stop_offset_pct: Stop-limit offset below current price (default 1.5%)
+            proximity_pct: Price proximity threshold for resubmit (default 0.75%)
+        """
+        self.symbols = symbols
+        self.coverage_threshold = coverage_threshold
+        self.stop_offset_pct = stop_offset_pct
+        self.proximity_pct = proximity_pct
+
+        print(f"\n{'='*70}")
+        print("MOMENTUM DCA STRATEGY INITIALIZED")
+        print(f"{'='*70}")
+        print(f"Symbols: {', '.join(symbols)}")
+        print(f"Coverage Threshold: {coverage_threshold * 100}%")
+        print(f"Stop Offset: {stop_offset_pct * 100}%")
+        print(f"Proximity Threshold: {proximity_pct * 100}%")
+        print(f"{'='*70}\n")
+
+    def analyze_symbol(self, symbol: str, metrics: Dict,
+                       current_position: Optional[Dict] = None,
+                       open_orders: Optional[List[Dict]] = None) -> Dict:
+        """
+        Analyze coverage for a symbol and generate signal
+
+        Args:
+            symbol: Stock symbol
+            metrics: Current metrics (must include current_price)
+            current_position: Current position info (if any)
+            open_orders: All open orders (strategy filters to this symbol)
+
+        Returns:
+            Signal dict with signal type, reason, and order details
+        """
+        current_price = metrics.get('current_price', 0)
+        if not current_price:
+            return {
+                'signal': 'NO_DATA',
+                'reason': 'No current price available',
+                'order': None
+            }
+
+        # No position → nothing to protect
+        if not current_position or float(current_position.get('quantity', 0)) <= 0:
+            return {
+                'signal': 'NO_POSITION',
+                'reason': f'No position in {symbol} to protect',
+                'order': None
+            }
+
+        position_qty = float(current_position['quantity'])
+        sell_orders = self._get_sell_orders_for_symbol(symbol, open_orders or [])
+        covered_qty = self._calculate_coverage(sell_orders)
+        coverage_pct = (covered_qty / position_qty) * 100 if position_qty > 0 else 0
+
+        # Already covered
+        if coverage_pct >= self.coverage_threshold * 100:
+            return {
+                'signal': 'COVERED',
+                'reason': (f'{symbol}: {coverage_pct:.1f}% covered '
+                           f'({covered_qty:.4f}/{position_qty:.4f} shares), '
+                           f'threshold {self.coverage_threshold * 100}%'),
+                'order': None
+            }
+
+        # Under-covered — calculate gap
+        gap_qty = (self.coverage_threshold * position_qty) - covered_qty
+        gap_qty = self._round_quantity(symbol, gap_qty)
+
+        if gap_qty <= 0:
+            return {
+                'signal': 'COVERED',
+                'reason': f'{symbol}: gap rounds to zero',
+                'order': None
+            }
+
+        # Check price proximity to existing sell orders
+        nearest_order = self._find_nearest_order(current_price, sell_orders)
+
+        if nearest_order:
+            order_price = nearest_order.get('limit_price') or nearest_order.get('stop_price')
+            if order_price and self._is_within_proximity(current_price, order_price):
+                return {
+                    'signal': 'RESUBMIT',
+                    'reason': (f'{symbol}: {coverage_pct:.1f}% covered, '
+                               f'price ${current_price:.2f} within {self.proximity_pct * 100}% '
+                               f'of order @ ${order_price:.2f}. '
+                               f'Resubmitting {gap_qty} shares at ${order_price:.2f}'),
+                    'order': {
+                        'action': 'limit_sell',
+                        'symbol': symbol,
+                        'quantity': gap_qty,
+                        'price': order_price,
+                        'current_price': current_price,
+                    }
+                }
+
+        # Price moved too far — new stop-limit
+        stop_price = round(current_price * (1 - self.stop_offset_pct), 2)
+        limit_price = stop_price
+
+        return {
+            'signal': 'COVER_GAP',
+            'reason': (f'{symbol}: {coverage_pct:.1f}% covered, '
+                       f'need {gap_qty} more shares protected. '
+                       f'Placing stop-limit sell @ ${stop_price:.2f} '
+                       f'(-{self.stop_offset_pct * 100}%)'),
+            'order': {
+                'action': 'stop_limit_sell',
+                'symbol': symbol,
+                'quantity': gap_qty,
+                'stop_price': stop_price,
+                'limit_price': limit_price,
+                'current_price': current_price,
+            }
+        }
+
+    def _get_sell_orders_for_symbol(self, symbol: str,
+                                    orders: List[Dict]) -> List[Dict]:
+        """Filter to SELL orders for a given symbol (all types)"""
+        return [
+            o for o in orders
+            if o.get('symbol') == symbol and o.get('side') == 'SELL'
+        ]
+
+    def _calculate_coverage(self, sell_orders: List[Dict]) -> float:
+        """Sum quantity covered by all sell orders"""
+        return sum(float(o.get('quantity', 0)) for o in sell_orders)
+
+    def _find_nearest_order(self, current_price: float,
+                            sell_orders: List[Dict]) -> Optional[Dict]:
+        """Find the sell order whose price is closest to current price"""
+        best = None
+        best_dist = float('inf')
+
+        for order in sell_orders:
+            price = order.get('limit_price') or order.get('stop_price')
+            if price is None:
+                continue
+            dist = abs(current_price - price) / price
+            if dist < best_dist:
+                best_dist = dist
+                best = order
+
+        return best
+
+    def _is_within_proximity(self, current_price: float,
+                             order_price: float) -> bool:
+        """Check if current price is within proximity_pct of order price"""
+        return abs(current_price - order_price) / order_price <= self.proximity_pct
+
+    def _round_quantity(self, symbol: str, quantity: float) -> float:
+        """Round quantity appropriately for the asset type"""
+        if symbol == 'BTC':
+            return round(quantity, 4)
+        return int(quantity)
+
+    def format_signal(self, symbol: str, signal_data: Dict) -> str:
+        """Format signal for display"""
+        lines = [
+            f"\n{'='*70}",
+            f"MOMENTUM DCA: {symbol}",
+            f"{'='*70}",
+            f"Signal: {signal_data['signal']}",
+            f"Reason: {signal_data['reason']}",
+        ]
+
+        if signal_data['order']:
+            order = signal_data['order']
+            lines.append("")
+            lines.append("Order Details:")
+            lines.append(f"  Action: {order['action'].upper()}")
+            lines.append(f"  Quantity: {order['quantity']}")
+            lines.append(f"  Current Price: ${order['current_price']:,.2f}")
+
+            if order['action'] == 'stop_limit_sell':
+                lines.append(f"  Stop Price: ${order['stop_price']:,.2f}")
+                lines.append(f"  Limit Price: ${order['limit_price']:,.2f}")
+            elif order['action'] == 'limit_sell':
+                lines.append(f"  Limit Price: ${order['price']:,.2f}")
+
+        lines.append(f"{'='*70}\n")
+        return '\n'.join(lines)
+
+    def calculate_position_size(self, symbol: str, price: float,
+                                available_cash: float) -> float:
+        """Calculate position size (not primary for this strategy but kept for interface)"""
+        if symbol == 'BTC':
+            return round(available_cash * 0.25 / price, 4)
+        return int(available_cash * 0.25 / price)

--- a/utils/safe_cash_bot.py
+++ b/utils/safe_cash_bot.py
@@ -488,6 +488,76 @@ class SafeCashBot:
             print(f"{'='*70}\n")
             return None
 
+    def place_stop_limit_sell_order(self, symbol, quantity, stop_price, limit_price, dry_run=True):
+        """
+        Place a stop-limit sell order
+
+        Args:
+            symbol: Stock ticker
+            quantity: Number of shares
+            stop_price: Price that triggers the order
+            limit_price: Minimum price to accept once triggered
+            dry_run: If True, simulates order without execution
+        """
+        print(f"\n{'='*70}")
+        print(f"🛑 STOP-LIMIT SELL ORDER - {'DRY RUN' if dry_run else 'LIVE'}")
+        print(f"{'='*70}")
+
+        # Check if we have the position
+        positions = self.get_positions()
+        position = next((p for p in positions if p['symbol'] == symbol), None)
+
+        print(f"   Account: {self.account_number}")
+        print(f"   Symbol: {symbol}")
+        print(f"   Quantity: {quantity}")
+        print(f"   Stop Price: ${stop_price:.2f}")
+        print(f"   Limit Price: ${limit_price:.2f}")
+        print(f"   Total Value: ${quantity * limit_price:.2f}")
+
+        if not position:
+            print(f"   Validation: ❌ No position in {symbol}")
+            print(f"\n❌ Order rejected: You don't own {symbol}")
+            print(f"{'='*70}\n")
+            return None
+
+        if quantity > position['quantity']:
+            print(f"   Validation: ❌ Insufficient shares (have {position['quantity']})")
+            print(f"\n❌ Order rejected: Can't sell {quantity} shares, only own {position['quantity']}")
+            print(f"{'='*70}\n")
+            return None
+
+        print("   Validation: ✅ Valid stop-limit sell order")
+
+        if dry_run:
+            print("\n⚠️  DRY RUN MODE - Order not executed")
+            print("   To execute real orders, call with dry_run=False")
+            print(f"{'='*70}\n")
+            return None
+
+        # Execute real order
+        try:
+            print("\n🚀 Executing order...")
+            order = r.orders.order_sell_stop_limit(
+                symbol=symbol,
+                quantity=quantity,
+                limitPrice=limit_price,
+                stopPrice=stop_price,
+                account_number=self.account_number,
+                timeInForce='gtc'
+            )
+
+            print("✅ Order placed successfully!")
+            print(f"   Order ID: {order.get('id', 'N/A')}")
+            print(f"   State: {order.get('state', 'N/A')}")
+            print(f"{'='*70}\n")
+
+            return order
+
+        except Exception as e:
+            print(f"❌ Order failed: {e}")
+            print(f"{'='*70}\n")
+            return None
+
     def get_quote(self, symbol):
         """Get real-time quote"""
         try:


### PR DESCRIPTION
## Summary

Implements MomentumDcaStrategy as the new default strategy that monitors open sell orders and maintains minimum 20% coverage per position. Two-tier gap filling: resubmits at original price if within 0.75% proximity, otherwise places stop-limit at -1.5% below current price.

## Changes

- New `MomentumDcaStrategy` class with dual-mode gap coverage
- `place_stop_limit_sell_order()` method added to SafeCashBot
- `--strategy` CLI arg to switch between momentum_dca (default) and breakout
- 25 comprehensive unit tests covering coverage, pricing, proximity, and edge cases

## Test Plan

- Run `python -m pytest tests/test_momentum_dca.py -v` — all 25 tests passing
- Run `python -m pytest tests/ -v` — all 31 tests passing (existing tests unaffected)
- Dry run: `python -m trading_system.main` — defaults to momentum_dca
- Verify backward compatibility: `python -m trading_system.main --strategy breakout`

🤖 Generated with Claude Code