### PR TITLE
Add momentum DCA strategy using entity classes

### DIFF
--- a/tests/test_momentum_dca.py
+++ b/tests/test_momentum_dca.py
@@ -1,0 +1,305 @@
+"""
+Tests for MomentumDcaStrategy using Ticker/Order entities
+"""
+from trading_system.strategies.momentum_dca_strategy import MomentumDcaStrategy
+from trading_system.entities.Order import Order
+from trading_system.entities.OrderType import OrderType
+from trading_system.entities.Ticker import Ticker
+from trading_system.state.state_manager import StateManager
+
+
+def _make_strategy(**kwargs):
+    defaults = dict(symbols=['BTC', 'SPY'], coverage_threshold=0.20,
+                    stop_offset_pct=0.015, proximity_pct=0.0075)
+    defaults.update(kwargs)
+    return MomentumDcaStrategy(**defaults)
+
+
+def _make_position(symbol, quantity, price):
+    return {'symbol': symbol, 'quantity': quantity, 'current_price': price,
+            'equity': quantity * price}
+
+
+def _make_ticker(orders=None):
+    return Ticker(orders or [])
+
+
+def _sell_order(size, price, order_type=OrderType.LIMIT):
+    return Order(size=size, price=price, order_type=order_type)
+
+
+class TestCoverageCalculation:
+    def test_fully_covered(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(25, 460.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVERED'
+        assert signal['order'] is None
+
+    def test_exactly_at_threshold(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(20, 460.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVERED'
+
+    def test_under_covered_no_existing_orders(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker()
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['action'] == 'stop_limit_sell'
+        assert signal['order']['quantity'] == 20
+
+    def test_partial_coverage(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(10, 460.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['order'] is not None
+        assert signal['order']['quantity'] == 10
+
+    def test_multiple_orders_count(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([
+            _sell_order(5, 460.0, OrderType.LIMIT),
+            _sell_order(5, 440.0, OrderType.STOP),
+            _sell_order(5, 438.0, OrderType.STOP_LIMIT),
+            _sell_order(5, 435.0, OrderType.LIMIT),
+        ])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVERED'
+
+    def test_invalid_orders_not_counted(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        order = _sell_order(25, 460.0)
+        order.mark_invalid()
+        ticker = _make_ticker([order])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['quantity'] == 20
+
+
+class TestGapQuantity:
+    def test_gap_from_zero(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 200, 450.0)
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, _make_ticker())
+        assert signal['order']['quantity'] == 40
+
+    def test_gap_from_partial(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 200, 450.0)
+        ticker = _make_ticker([_sell_order(15, 460.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['order']['quantity'] == 25
+
+    def test_btc_fractional_quantity(self):
+        strategy = _make_strategy()
+        position = _make_position('BTC', 0.5, 100000.0)
+        signal = strategy.analyze_symbol('BTC', {'current_price': 100000.0}, position, _make_ticker())
+        assert signal['order']['quantity'] == 0.1
+        assert round(signal['order']['quantity'], 4) == signal['order']['quantity']
+
+    def test_stock_whole_shares(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 7, 450.0)
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, _make_ticker())
+        assert signal['order']['quantity'] == 1
+        assert isinstance(signal['order']['quantity'], int)
+
+
+class TestStopLimitPricing:
+    def test_stop_price_at_negative_1_5_pct(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, _make_ticker())
+        expected = round(450.0 * 0.985, 2)
+        assert signal['order']['stop_price'] == expected
+        assert signal['order']['limit_price'] == expected
+
+    def test_stop_equals_limit(self):
+        strategy = _make_strategy()
+        position = _make_position('BTC', 1.0, 100000.0)
+        signal = strategy.analyze_symbol('BTC', {'current_price': 100000.0}, position, _make_ticker())
+        assert signal['order']['stop_price'] == signal['order']['limit_price']
+
+
+class TestPriceProximity:
+    def test_within_proximity_resubmits(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(10, 452.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['action'] == 'limit_sell'
+        assert signal['order']['price'] == 452.0
+
+    def test_outside_proximity_new_stop_limit(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(10, 500.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'COVER_GAP'
+        assert signal['order']['action'] == 'stop_limit_sell'
+
+    def test_resubmit_uses_order_entity_price(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 448.0)
+        ticker = _make_ticker([_sell_order(10, 450.0)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 448.0}, position, ticker)
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['price'] == 450.0
+        assert signal['order']['current_price'] == 448.0
+
+    def test_proximity_with_stop_order(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([_sell_order(10, 449.0, OrderType.STOP)])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'RESUBMIT'
+
+    def test_nearest_order_selected(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        ticker = _make_ticker([
+            _sell_order(5, 500.0),
+            _sell_order(5, 451.0),
+        ])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] == 'RESUBMIT'
+        assert signal['order']['price'] == 451.0
+
+
+class TestEdgeCases:
+    def test_no_position(self):
+        strategy = _make_strategy()
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, None, _make_ticker())
+        assert signal['signal'] == 'NO_POSITION'
+
+    def test_zero_quantity_position(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 0, 450.0)
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, _make_ticker())
+        assert signal['signal'] == 'NO_POSITION'
+
+    def test_no_price_data(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        signal = strategy.analyze_symbol('SPY', {}, position, _make_ticker())
+        assert signal['signal'] == 'NO_DATA'
+
+    def test_format_signal_cover_gap(self):
+        strategy = _make_strategy()
+        signal = {
+            'signal': 'COVER_GAP', 'reason': 'test',
+            'order': {'action': 'stop_limit_sell', 'symbol': 'SPY', 'quantity': 20,
+                      'stop_price': 443.25, 'limit_price': 443.25, 'current_price': 450.0}
+        }
+        output = strategy.format_signal('SPY', signal)
+        assert 'COVER_GAP' in output
+        assert 'Stop Price' in output
+
+    def test_format_signal_resubmit(self):
+        strategy = _make_strategy()
+        signal = {
+            'signal': 'RESUBMIT', 'reason': 'test',
+            'order': {'action': 'limit_sell', 'symbol': 'SPY', 'quantity': 10,
+                      'price': 452.0, 'current_price': 450.0}
+        }
+        output = strategy.format_signal('SPY', signal)
+        assert 'RESUBMIT' in output
+        assert 'Limit Price' in output
+
+    def test_format_signal_covered(self):
+        strategy = _make_strategy()
+        signal = {'signal': 'COVERED', 'reason': 'fully covered', 'order': None}
+        output = strategy.format_signal('SPY', signal)
+        assert 'COVERED' in output
+
+
+class TestLoadBrokerSellOrders:
+    """Test StateManager.load_broker_sell_orders converts raw dicts to Ticker"""
+
+    def test_filters_to_sell_orders_only(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'BUY', 'order_type': 'Limit',
+             'quantity': 50, 'limit_price': 440.0, 'stop_price': None},
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 20, 'limit_price': 460.0, 'stop_price': None},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        ticker = mgr.get_ticker('SPY')
+        assert len(ticker.orders) == 1
+        assert ticker.orders[0].size == 20
+
+    def test_filters_by_symbol(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'AAPL', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 30, 'limit_price': 180.0, 'stop_price': None},
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 20, 'limit_price': 460.0, 'stop_price': None},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        ticker = mgr.get_ticker('SPY')
+        assert len(ticker.orders) == 1
+        assert ticker.orders[0].price == 460.0
+
+    def test_maps_order_types(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 5, 'limit_price': 460.0, 'stop_price': None},
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Stop Limit',
+             'quantity': 5, 'limit_price': 438.0, 'stop_price': 440.0},
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Stop Loss',
+             'quantity': 5, 'limit_price': None, 'stop_price': 440.0},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        ticker = mgr.get_ticker('SPY')
+        assert len(ticker.orders) == 3
+        assert ticker.orders[0].order_type == OrderType.LIMIT
+        assert ticker.orders[1].order_type == OrderType.STOP_LIMIT
+        assert ticker.orders[2].order_type == OrderType.STOP
+
+    def test_uses_limit_price_over_stop_price(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Stop Limit',
+             'quantity': 10, 'limit_price': 438.0, 'stop_price': 440.0},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        ticker = mgr.get_ticker('SPY')
+        assert ticker.orders[0].price == 438.0
+
+    def test_falls_back_to_stop_price(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Stop Loss',
+             'quantity': 10, 'limit_price': None, 'stop_price': 440.0},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        ticker = mgr.get_ticker('SPY')
+        assert ticker.orders[0].price == 440.0
+
+    def test_replaces_existing_ticker(self):
+        mgr = StateManager()
+        mgr.load_broker_sell_orders('SPY', [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 10, 'limit_price': 450.0, 'stop_price': None},
+        ])
+        assert len(mgr.get_ticker('SPY').orders) == 1
+
+        mgr.load_broker_sell_orders('SPY', [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 5, 'limit_price': 460.0, 'stop_price': None},
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 5, 'limit_price': 470.0, 'stop_price': None},
+        ])
+        assert len(mgr.get_ticker('SPY').orders) == 2

--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from trading_system.data_providers.twelve_data import TwelveDataProvider  # noqa: E402
 from trading_system.utils.metrics import MetricsCalculator  # noqa: E402
 from trading_system.strategies.breakout_strategy import BreakoutStrategy  # noqa: E402
+from trading_system.strategies.momentum_dca_strategy import MomentumDcaStrategy  # noqa: E402
 from trading_system.state.state_manager import StateManager  # noqa: E402
 from utils.safe_cash_bot import SafeCashBot  # noqa: E402
 
@@ -23,7 +24,8 @@ class TradingSystem:
     """Main trading system orchestrator"""
 
     def __init__(self, twelve_data_api_key: str, symbols: List[str],
-                 position_size_pct: float = 0.25, dry_run: bool = True):
+                 position_size_pct: float = 0.25, dry_run: bool = True,
+                 strategy_name: str = 'momentum_dca'):
         """
         Initialize trading system
 
@@ -32,20 +34,27 @@ class TradingSystem:
             symbols: List of symbols to trade
             position_size_pct: Position size as percentage of portfolio
             dry_run: If True, simulates orders without execution
+            strategy_name: Strategy to use ('momentum_dca' or 'breakout')
         """
         self.symbols = symbols
         self.dry_run = dry_run
+        self.strategy_name = strategy_name
 
         # Initialize components
         self.data_provider = TwelveDataProvider(twelve_data_api_key)
         self.metrics_calculator = MetricsCalculator()
-        self.strategy = BreakoutStrategy(symbols, position_size_pct)
         self.state_manager = StateManager()
         self.trading_bot = SafeCashBot()
+
+        if strategy_name == 'momentum_dca':
+            self.strategy = MomentumDcaStrategy(symbols)
+        else:
+            self.strategy = BreakoutStrategy(symbols, position_size_pct)
 
         print(f"\n{'='*70}")
         print("TRADING SYSTEM INITIALIZED")
         print(f"{'='*70}")
+        print(f"Strategy: {strategy_name}")
         print(f"Symbols: {', '.join(symbols)}")
         print(f"Mode: {'DRY RUN (Simulation)' if dry_run else 'LIVE TRADING'}")
         print(f"Position Size: {position_size_pct * 100}% per symbol")
@@ -102,13 +111,15 @@ class TradingSystem:
 
         return metrics
 
-    def execute_strategy(self, symbol: str, metrics: Dict) -> Dict:
+    def execute_strategy(self, symbol: str, metrics: Dict,
+                         open_orders: List[Dict] = None) -> Dict:
         """
         Execute strategy for a symbol
 
         Args:
             symbol: Stock symbol
             metrics: Calculated metrics
+            open_orders: Open orders from broker (used by momentum_dca)
 
         Returns:
             Signal data
@@ -120,8 +131,13 @@ class TradingSystem:
             None
         )
 
-        # Analyze and generate signal
-        signal = self.strategy.analyze_symbol(symbol, metrics, current_position)
+        if self.strategy_name == 'momentum_dca':
+            # Load broker sell orders into the symbol's Ticker
+            self.state_manager.load_broker_sell_orders(symbol, open_orders or [])
+            ticker = self.state_manager.get_ticker(symbol)
+            signal = self.strategy.analyze_symbol(symbol, metrics, current_position, ticker)
+        else:
+            signal = self.strategy.analyze_symbol(symbol, metrics, current_position)
 
         return signal
 
@@ -145,9 +161,12 @@ class TradingSystem:
 
         if order['action'] == 'buy':
             self._execute_buy_order(symbol, order)
-
         elif order['action'] == 'sell':
             self._execute_sell_order(symbol, order)
+        elif order['action'] == 'stop_limit_sell':
+            self._execute_stop_limit_sell_order(symbol, order)
+        elif order['action'] == 'limit_sell':
+            self._execute_limit_sell_resubmit(symbol, order)
 
     def _execute_buy_order(self, symbol: str, order: Dict):
         """Execute buy order"""
@@ -230,6 +249,74 @@ class TradingSystem:
                 )
                 print(f"Order placed: {order_id}")
 
+    def _execute_stop_limit_sell_order(self, symbol: str, order: Dict):
+        """Execute stop-limit sell order for gap coverage"""
+        quantity = order['quantity']
+        stop_price = order['stop_price']
+        limit_price = order['limit_price']
+
+        order_details = {
+            'quantity': quantity,
+            'stop_price': stop_price,
+            'limit_price': limit_price,
+            'price': limit_price,
+            'trigger': 'coverage_gap',
+            'order_type': 'stop_limit'
+        }
+        self.state_manager.queue_sell_order(symbol, order_details)
+
+        print(f"\n{'='*70}")
+        print(f"EXECUTING STOP-LIMIT SELL: {symbol}")
+        print(f"{'='*70}")
+        print(f"Quantity: {quantity}")
+        print(f"Stop Price: ${stop_price:,.2f}")
+        print(f"Limit Price: ${limit_price:,.2f}")
+        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE'}")
+        print(f"{'='*70}\n")
+
+        if not self.dry_run:
+            result = self.trading_bot.place_stop_limit_sell_order(
+                symbol, quantity, stop_price, limit_price, dry_run=False
+            )
+            if result:
+                order_id = result.get('id', 'unknown')
+                self.state_manager.update_order_status(
+                    symbol, 'sell', 'placed', order_id
+                )
+                print(f"Order placed: {order_id}")
+
+    def _execute_limit_sell_resubmit(self, symbol: str, order: Dict):
+        """Execute limit sell resubmit at original order price"""
+        quantity = order['quantity']
+        price = order['price']
+
+        order_details = {
+            'quantity': quantity,
+            'price': price,
+            'trigger': 'resubmit',
+            'order_type': 'limit'
+        }
+        self.state_manager.queue_sell_order(symbol, order_details)
+
+        print(f"\n{'='*70}")
+        print(f"RESUBMITTING LIMIT SELL: {symbol}")
+        print(f"{'='*70}")
+        print(f"Quantity: {quantity}")
+        print(f"Limit Price: ${price:,.2f} (original order price)")
+        print(f"Mode: {'DRY RUN' if self.dry_run else 'LIVE'}")
+        print(f"{'='*70}\n")
+
+        if not self.dry_run:
+            result = self.trading_bot.place_sell_order(
+                symbol, quantity, price, dry_run=False
+            )
+            if result:
+                order_id = result.get('id', 'unknown')
+                self.state_manager.update_order_status(
+                    symbol, 'sell', 'placed', order_id
+                )
+                print(f"Order placed: {order_id}")
+
     def print_portfolio_allocation(self):
         """Print current portfolio allocation summary"""
         print(f"\n{'='*70}")
@@ -293,6 +380,11 @@ class TradingSystem:
         # Print initial portfolio allocation
         self.print_portfolio_allocation()
 
+        # Fetch open orders once (used by momentum_dca)
+        open_orders = []
+        if self.strategy_name == 'momentum_dca':
+            open_orders = self.trading_bot.get_open_orders()
+
         for symbol in self.symbols:
             print(f"\n{'#'*70}")
             print(f"Processing {symbol}")
@@ -307,7 +399,7 @@ class TradingSystem:
                 print(self.metrics_calculator.format_metrics(symbol, metrics))
 
                 # 3. Execute strategy
-                signal = self.execute_strategy(symbol, metrics)
+                signal = self.execute_strategy(symbol, metrics, open_orders)
 
                 # 4. Process signal
                 self.process_signal(symbol, signal)
@@ -359,7 +451,7 @@ def main():
     load_dotenv()
 
     # Parse arguments
-    parser = argparse.ArgumentParser(description='30-Day Breakout Trading System')
+    parser = argparse.ArgumentParser(description='Trading System')
     parser.add_argument(
         '--live',
         action='store_true',
@@ -375,6 +467,14 @@ def main():
         type=int,
         default=5,
         help='Minutes between runs in continuous mode (default: 5)'
+    )
+
+    parser.add_argument(
+        '--strategy',
+        type=str,
+        choices=['momentum_dca', 'breakout'],
+        default='momentum_dca',
+        help='Trading strategy to use (default: momentum_dca)'
     )
 
     args = parser.parse_args()
@@ -404,7 +504,8 @@ def main():
         twelve_data_api_key=api_key,
         symbols=symbols,
         position_size_pct=0.25,
-        dry_run=not args.live
+        dry_run=not args.live,
+        strategy_name=args.strategy
     )
 
     # Run system

--- a/trading_system/state/state_manager.py
+++ b/trading_system/state/state_manager.py
@@ -166,6 +166,37 @@ class StateManager:
         }
         self.state['last_updated'] = datetime.now().isoformat()
 
+    def load_broker_sell_orders(self, symbol: str, broker_orders: List[Dict]):
+        """Convert raw broker sell orders into Order entities on the symbol's Ticker.
+
+        Filters to SELL orders for the given symbol, maps broker order_type
+        strings to OrderType enums, and uses limit_price (or stop_price) as
+        Order.price. Replaces any existing orders on the Ticker.
+        """
+        self.get_symbol_state(symbol)
+
+        ORDER_TYPE_MAP = {
+            'Limit': OrderType.LIMIT,
+            'Market': OrderType.MARKET,
+            'Stop Loss': OrderType.STOP,
+            'Stop Limit': OrderType.STOP_LIMIT,
+        }
+
+        orders = []
+        for raw in broker_orders:
+            if raw.get('symbol') != symbol:
+                continue
+            if raw.get('side') != 'SELL':
+                continue
+
+            order_type = ORDER_TYPE_MAP.get(raw.get('order_type'), OrderType.MARKET)
+            price = raw.get('limit_price') or raw.get('stop_price') or 0
+            size = float(raw.get('quantity', 0))
+
+            orders.append(Order(size=size, price=price, order_type=order_type))
+
+        self.tickers[symbol] = Ticker(orders)
+
     def get_all_symbols(self) -> List[str]:
         """Get list of all tracked symbols"""
         return list(self.state['symbols'].keys())

--- a/trading_system/strategies/momentum_dca_strategy.py
+++ b/trading_system/strategies/momentum_dca_strategy.py
@@ -1,0 +1,158 @@
+"""
+Momentum DCA Strategy
+Ensures at least 20% of each position is covered by sell orders at all times.
+If coverage is below threshold:
+  - Price within 0.75% of existing order -> resubmit at original price
+  - Price moved >0.75% -> place stop-limit at -1.5% below current price
+
+Uses Ticker/Order entities for order tracking (no raw dicts).
+"""
+
+from typing import Dict, Optional, List
+
+from trading_system.entities.Ticker import Ticker
+
+
+class MomentumDcaStrategy:
+    """
+    Momentum Dollar-Cost Averaging Strategy
+
+    Monitors open sell orders (via Ticker) against positions and maintains a
+    minimum coverage threshold. Places protective orders to fill gaps.
+    """
+
+    def __init__(self, symbols: List[str], coverage_threshold: float = 0.20,
+                 stop_offset_pct: float = 0.015, proximity_pct: float = 0.0075):
+        self.symbols = symbols
+        self.coverage_threshold = coverage_threshold
+        self.stop_offset_pct = stop_offset_pct
+        self.proximity_pct = proximity_pct
+
+    def analyze_symbol(self, symbol: str, metrics: Dict,
+                       current_position: Optional[Dict],
+                       ticker: Ticker) -> Dict:
+        """
+        Analyze coverage for a symbol and generate signal.
+
+        Args:
+            symbol: Stock symbol
+            metrics: Must include 'current_price'
+            current_position: Broker position dict (or None)
+            ticker: Ticker loaded with the symbol's open sell orders
+        """
+        current_price = metrics.get('current_price', 0)
+        if not current_price:
+            return {'signal': 'NO_DATA', 'reason': 'No current price available', 'order': None}
+
+        if not current_position or float(current_position.get('quantity', 0)) <= 0:
+            return {'signal': 'NO_POSITION', 'reason': f'No position in {symbol}', 'order': None}
+
+        position_qty = float(current_position['quantity'])
+        valid_orders = ticker.get_valid_orders()
+        covered_qty = sum(o.size for o in valid_orders)
+        coverage_pct = (covered_qty / position_qty) * 100 if position_qty > 0 else 0
+
+        if coverage_pct >= self.coverage_threshold * 100:
+            return {
+                'signal': 'COVERED',
+                'reason': (f'{symbol}: {coverage_pct:.1f}% covered '
+                           f'({covered_qty:.4f}/{position_qty:.4f}), '
+                           f'threshold {self.coverage_threshold * 100}%'),
+                'order': None
+            }
+
+        # Under-covered — calculate gap
+        gap_qty = (self.coverage_threshold * position_qty) - covered_qty
+        gap_qty = self._round_quantity(symbol, gap_qty)
+
+        if gap_qty <= 0:
+            return {'signal': 'COVERED', 'reason': f'{symbol}: gap rounds to zero', 'order': None}
+
+        # Check price proximity to nearest existing sell order
+        nearest = self._find_nearest_order(current_price, valid_orders)
+
+        if nearest:
+            order_price = nearest.price
+            if order_price and self._is_within_proximity(current_price, order_price):
+                return {
+                    'signal': 'RESUBMIT',
+                    'reason': (f'{symbol}: {coverage_pct:.1f}% covered, '
+                               f'price ${current_price:.2f} within {self.proximity_pct * 100}% '
+                               f'of order @ ${order_price:.2f}. '
+                               f'Resubmitting {gap_qty} shares at ${order_price:.2f}'),
+                    'order': {
+                        'action': 'limit_sell',
+                        'symbol': symbol,
+                        'quantity': gap_qty,
+                        'price': order_price,
+                        'current_price': current_price,
+                    }
+                }
+
+        # Price moved too far — new stop-limit
+        stop_price = round(current_price * (1 - self.stop_offset_pct), 2)
+
+        return {
+            'signal': 'COVER_GAP',
+            'reason': (f'{symbol}: {coverage_pct:.1f}% covered, '
+                       f'need {gap_qty} more shares protected. '
+                       f'Placing stop-limit sell @ ${stop_price:.2f} '
+                       f'(-{self.stop_offset_pct * 100}%)'),
+            'order': {
+                'action': 'stop_limit_sell',
+                'symbol': symbol,
+                'quantity': gap_qty,
+                'stop_price': stop_price,
+                'limit_price': stop_price,
+                'current_price': current_price,
+            }
+        }
+
+    def _find_nearest_order(self, current_price, valid_orders):
+        """Find the Order entity whose price is closest to current price"""
+        best = None
+        best_dist = float('inf')
+        for order in valid_orders:
+            if not order.price:
+                continue
+            dist = abs(current_price - order.price) / order.price
+            if dist < best_dist:
+                best_dist = dist
+                best = order
+        return best
+
+    def _is_within_proximity(self, current_price, order_price):
+        return abs(current_price - order_price) / order_price <= self.proximity_pct
+
+    def _round_quantity(self, symbol, quantity):
+        if symbol == 'BTC':
+            return round(quantity, 4)
+        return int(quantity)
+
+    def calculate_position_size(self, symbol, price, available_cash):
+        if symbol == 'BTC':
+            return round(available_cash * 0.25 / price, 4)
+        return int(available_cash * 0.25 / price)
+
+    def format_signal(self, symbol, signal_data):
+        lines = [
+            f"\n{'='*70}",
+            f"MOMENTUM DCA: {symbol}",
+            f"{'='*70}",
+            f"Signal: {signal_data['signal']}",
+            f"Reason: {signal_data['reason']}",
+        ]
+        if signal_data['order']:
+            order = signal_data['order']
+            lines.append("")
+            lines.append("Order Details:")
+            lines.append(f"  Action: {order['action'].upper()}")
+            lines.append(f"  Quantity: {order['quantity']}")
+            lines.append(f"  Current Price: ${order['current_price']:,.2f}")
+            if order['action'] == 'stop_limit_sell':
+                lines.append(f"  Stop Price: ${order['stop_price']:,.2f}")
+                lines.append(f"  Limit Price: ${order['limit_price']:,.2f}")
+            elif order['action'] == 'limit_sell':
+                lines.append(f"  Limit Price: ${order['price']:,.2f}")
+        lines.append(f"{'='*70}\n")
+        return '\n'.join(lines)

--- a/utils/safe_cash_bot.py
+++ b/utils/safe_cash_bot.py
@@ -488,6 +488,73 @@ class SafeCashBot:
             print(f"{'='*70}\n")
             return None
 
+    def place_stop_limit_sell_order(self, symbol, quantity, stop_price, limit_price, dry_run=True):
+        """
+        Place a stop-limit sell order
+
+        Args:
+            symbol: Stock ticker
+            quantity: Number of shares
+            stop_price: Price that triggers the order
+            limit_price: Minimum price to accept once triggered
+            dry_run: If True, simulates order without execution
+        """
+        print(f"\n{'='*70}")
+        print(f"STOP-LIMIT SELL ORDER - {'DRY RUN' if dry_run else 'LIVE'}")
+        print(f"{'='*70}")
+
+        positions = self.get_positions()
+        position = next((p for p in positions if p['symbol'] == symbol), None)
+
+        print(f"   Account: {self.account_number}")
+        print(f"   Symbol: {symbol}")
+        print(f"   Quantity: {quantity}")
+        print(f"   Stop Price: ${stop_price:.2f}")
+        print(f"   Limit Price: ${limit_price:.2f}")
+        print(f"   Total Value: ${quantity * limit_price:.2f}")
+
+        if not position:
+            print(f"   Validation: No position in {symbol}")
+            print(f"\nOrder rejected: You don't own {symbol}")
+            print(f"{'='*70}\n")
+            return None
+
+        if quantity > position['quantity']:
+            print(f"   Validation: Insufficient shares (have {position['quantity']})")
+            print(f"\nOrder rejected: Can't sell {quantity} shares, only own {position['quantity']}")
+            print(f"{'='*70}\n")
+            return None
+
+        print("   Validation: Valid stop-limit sell order")
+
+        if dry_run:
+            print("\n   DRY RUN MODE - Order not executed")
+            print(f"{'='*70}\n")
+            return None
+
+        try:
+            print("\n   Executing order...")
+            order = r.orders.order_sell_stop_limit(
+                symbol=symbol,
+                quantity=quantity,
+                limitPrice=limit_price,
+                stopPrice=stop_price,
+                account_number=self.account_number,
+                timeInForce='gtc'
+            )
+
+            print("   Order placed successfully!")
+            print(f"   Order ID: {order.get('id', 'N/A')}")
+            print(f"   State: {order.get('state', 'N/A')}")
+            print(f"{'='*70}\n")
+
+            return order
+
+        except Exception as e:
+            print(f"   Order failed: {e}")
+            print(f"{'='*70}\n")
+            return None
+
     def get_quote(self, symbol):
         """Get real-time quote"""
         try:


### PR DESCRIPTION
## Summary

- New `MomentumDcaStrategy` that uses `Ticker`/`Order` entities for sell order coverage tracking — no entity class modifications needed
- `StateManager.load_broker_sell_orders()` converts raw broker dicts to Order entities on the symbol's Ticker, filtering to SELL orders and mapping order types
- `--strategy` CLI arg to switch between `momentum_dca` (default) and `breakout`
- `place_stop_limit_sell_order()` added to SafeCashBot
- 29 new tests covering coverage, proximity, gap pricing, broker conversion, and edge cases (57 total passing)

## How entities are used without modification

- `Order.size` → quantity for coverage sums
- `Order.price` → limit/stop price for proximity checks (equal in this strategy)
- `OrderType.STOP_LIMIT`, `.LIMIT`, `.STOP` → broker order type mapping
- `Ticker.get_valid_orders()` → filters invalid/filled orders from coverage calc

## Test plan

- `python -m pytest tests/ -v` — all 57 tests pass
- `python -m trading_system.main` — defaults to momentum_dca
- `python -m trading_system.main --strategy breakout` — backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)