### PR TITLE
Refresh stale sell orders when price rises

### DIFF
--- a/tests/test_momentum_dca.py
+++ b/tests/test_momentum_dca.py
@@ -1,6 +1,8 @@
 """
 Tests for MomentumDcaStrategy using Ticker/Order entities
 """
+from datetime import datetime, timedelta
+
 from trading_system.strategies.momentum_dca_strategy import MomentumDcaStrategy
 from trading_system.entities.Order import Order
 from trading_system.entities.OrderType import OrderType
@@ -430,3 +432,134 @@ class TestLoadBrokerSellOrders:
              'quantity': 5, 'limit_price': 470.0, 'stop_price': None},
         ])
         assert len(mgr.get_ticker('SPY').orders) == 2
+
+
+def _sell_order_with_age(size, price, order_type=OrderType.STOP_LIMIT,
+                         age_hours=48, order_id='test-order-123'):
+    created_at = datetime.now() - timedelta(hours=age_hours)
+    return Order(size=size, price=price, order_type=order_type,
+                 created_at=created_at, order_id=order_id)
+
+
+class TestStaleOrderRefresh:
+    """Stale orders (>1 day old, price risen above) trigger STALE_REFRESH"""
+
+    def test_stale_order_triggers_refresh(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        # Order at $443 placed 2 days ago; price now $460, ideal stop = $453.10
+        stale = _sell_order_with_age(20, 443.0, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['signal'] == 'STALE_REFRESH'
+        assert signal['cancel_order_id'] == 'test-order-123'
+        assert signal['order']['action'] == 'stop_limit_sell'
+        expected_stop = round(460.0 * 0.985, 2)
+        assert signal['order']['stop_price'] == expected_stop
+
+    def test_fresh_order_not_refreshed(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        fresh = _sell_order_with_age(20, 443.0, age_hours=12)
+        ticker = _make_ticker([fresh])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['signal'] != 'STALE_REFRESH'
+
+    def test_stale_but_price_not_risen(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 450.0)
+        # $443.25 is 1.5% below $450 — still at ideal offset
+        stale = _sell_order_with_age(20, 443.25, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 450.0}, position, ticker)
+        assert signal['signal'] != 'STALE_REFRESH'
+
+    def test_refresh_includes_paired_buy(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        stale = _sell_order_with_age(20, 443.0, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['paired_buy'] is not None
+        assert signal['paired_buy']['action'] == 'limit_buy'
+        stop = signal['order']['stop_price']
+        assert signal['paired_buy']['price'] == round(stop - 0.20, 2)
+
+    def test_refresh_preserves_quantity(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        stale = _sell_order_with_age(30, 443.0, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['order']['quantity'] == 30
+
+    def test_refresh_uses_hedge_symbol(self):
+        strategy = _make_strategy(hedge_symbol_map={'SPY': 'SH'})
+        position = _make_position('SPY', 100, 460.0)
+        stale = _sell_order_with_age(20, 443.0, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['order']['symbol'] == 'SH'
+
+    def test_order_without_created_at_not_refreshed(self):
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        old_style = _sell_order(20, 443.0, OrderType.STOP_LIMIT)
+        ticker = _make_ticker([old_style])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['signal'] != 'STALE_REFRESH'
+
+    def test_stale_refresh_priority_over_covered(self):
+        """Even if coverage >= 20%, stale orders should still be refreshed"""
+        strategy = _make_strategy()
+        position = _make_position('SPY', 100, 460.0)
+        # 25/100 = 25% > 20% threshold, but order is stale
+        stale = _sell_order_with_age(25, 443.0, age_hours=48)
+        ticker = _make_ticker([stale])
+        signal = strategy.analyze_symbol('SPY', {'current_price': 460.0}, position, ticker)
+        assert signal['signal'] == 'STALE_REFRESH'
+
+    def test_format_shows_stale_refresh(self):
+        strategy = _make_strategy()
+        cancel_order = _sell_order_with_age(20, 443.0, age_hours=48, order_id='abc-123')
+        signal = {
+            'signal': 'STALE_REFRESH', 'reason': 'test',
+            'cancel_order_id': 'abc-123',
+            'cancel_order': cancel_order,
+            'order': {'action': 'stop_limit_sell', 'symbol': 'SPY', 'quantity': 20,
+                      'stop_price': 453.10, 'limit_price': 453.10, 'current_price': 460.0},
+            'paired_buy': {'action': 'limit_buy', 'symbol': 'SPY', 'quantity': 20,
+                           'price': 452.90, 'current_price': 460.0},
+        }
+        output = strategy.format_signal('SPY', signal)
+        assert 'STALE_REFRESH' in output
+        assert 'abc-123' in output
+        assert 'Stale Order' in output
+
+
+class TestLoadBrokerSellOrdersTimestamp:
+    """Verify created_at and order_id pass through to Order entities"""
+
+    def test_created_at_passed_through(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Stop Limit',
+             'quantity': 20, 'limit_price': 443.0, 'stop_price': 445.0,
+             'created_at': '2026-02-07 10:30:00', 'order_id': 'abc-123'},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        order = mgr.get_ticker('SPY').orders[0]
+        assert order.created_at is not None
+        assert order.created_at.year == 2026
+        assert order.order_id == 'abc-123'
+
+    def test_missing_created_at_is_none(self):
+        mgr = StateManager()
+        broker_orders = [
+            {'symbol': 'SPY', 'side': 'SELL', 'order_type': 'Limit',
+             'quantity': 10, 'limit_price': 460.0, 'stop_price': None},
+        ]
+        mgr.load_broker_sell_orders('SPY', broker_orders)
+        order = mgr.get_ticker('SPY').orders[0]
+        assert order.created_at is None
+        assert order.order_id is None

--- a/trading_system/entities/Order.py
+++ b/trading_system/entities/Order.py
@@ -1,9 +1,11 @@
 class Order:
-    def __init__(self, size, price, order_type):
+    def __init__(self, size, price, order_type, created_at=None, order_id=None):
         self.size = size
         self.price = price
         self.order_type = order_type
         self.is_valid = True
+        self.created_at = created_at    # datetime or None
+        self.order_id = order_id        # str or None
 
     def mark_invalid(self) -> bool:
         self.is_valid = False

--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -169,6 +169,8 @@ class TradingSystem:
             self._execute_buy_order(symbol, order)
         elif order['action'] == 'sell':
             self._execute_sell_order(symbol, order)
+        elif order['action'] == 'stop_limit_sell' and signal.get('cancel_order_id'):
+            self._execute_stale_refresh(symbol, signal)
         elif order['action'] == 'stop_limit_sell':
             self._execute_stop_limit_sell_order(symbol, order)
             # Execute paired buy if present
@@ -329,6 +331,26 @@ class TradingSystem:
                     symbol, 'sell', 'placed', order_id
                 )
                 print(f"Order placed: {order_id}")
+
+    def _execute_stale_refresh(self, symbol: str, signal: Dict):
+        """Cancel a stale order and place replacement stop-limit sell + paired buy"""
+        cancel_id = signal['cancel_order_id']
+        order = signal['order']
+
+        if not self.dry_run:
+            cancelled = self.trading_bot.cancel_order(cancel_id, dry_run=False)
+            if not cancelled:
+                print(f"  Failed to cancel stale order {cancel_id}, skipping replacement")
+                return
+        else:
+            self.trading_bot.cancel_order(cancel_id, dry_run=True)
+
+        # Place replacement stop-limit sell
+        self._execute_stop_limit_sell_order(symbol, order)
+
+        # Place paired buy if present
+        if signal.get('paired_buy'):
+            self._execute_paired_limit_buy(symbol, signal['paired_buy'])
 
     def _execute_paired_limit_buy(self, symbol: str, buy_order: Dict):
         """Execute paired limit buy order below the stop-limit sell"""

--- a/trading_system/state/state_manager.py
+++ b/trading_system/state/state_manager.py
@@ -193,7 +193,18 @@ class StateManager:
             price = raw.get('limit_price') or raw.get('stop_price') or 0
             size = float(raw.get('quantity', 0))
 
-            orders.append(Order(size=size, price=price, order_type=order_type))
+            created_at = None
+            created_at_str = raw.get('created_at')
+            if created_at_str and created_at_str != 'N/A':
+                try:
+                    created_at = datetime.strptime(created_at_str, '%Y-%m-%d %H:%M:%S')
+                except ValueError:
+                    pass
+
+            orders.append(Order(
+                size=size, price=price, order_type=order_type,
+                created_at=created_at, order_id=raw.get('order_id'),
+            ))
 
         self.tickers[symbol] = Ticker(orders)
 

--- a/trading_system/strategies/momentum_dca_strategy.py
+++ b/trading_system/strategies/momentum_dca_strategy.py
@@ -9,6 +9,7 @@ If coverage is below threshold:
 Uses Ticker/Order entities for order tracking (no raw dicts).
 """
 
+from datetime import datetime, timedelta
 from typing import Dict, Optional, List
 
 from trading_system.entities.Ticker import Ticker
@@ -31,6 +32,7 @@ class MomentumDcaStrategy:
                  coverage_range_pct: float = 0.08,
                  buy_offset: float = 0.20,
                  lot_size: int = 150,
+                 stale_order_age_hours: int = 24,
                  hedge_symbol_map: Dict = None):
         self.symbols = symbols
         self.coverage_threshold = coverage_threshold
@@ -39,6 +41,7 @@ class MomentumDcaStrategy:
         self.coverage_range_pct = coverage_range_pct
         self.buy_offset = buy_offset
         self.lot_size = lot_size
+        self.stale_order_age_hours = stale_order_age_hours
         self.hedge_symbol_map = hedge_symbol_map if hedge_symbol_map is not None else self.DEFAULT_HEDGE_MAP
 
     def analyze_symbol(self, symbol: str, metrics: Dict,
@@ -70,6 +73,39 @@ class MomentumDcaStrategy:
 
         covered_qty = sum(o.size for o in in_range)
         coverage_pct = (covered_qty / position_qty) * 100 if position_qty > 0 else 0
+
+        # Check for stale orders before evaluating coverage
+        stale = self._find_stale_order(current_price, in_range)
+        if stale:
+            order_symbol = self.hedge_symbol_map.get(symbol, symbol)
+            stop_price = round(current_price * (1 - self.stop_offset_pct), 2)
+            buy_price = round(stop_price - self.buy_offset, 2)
+            age_days = (datetime.now() - stale.created_at).days
+            return {
+                'signal': 'STALE_REFRESH',
+                'reason': (f'{symbol}: Stale order — '
+                           f'{int(stale.size)} shares @ ${stale.price:.2f} '
+                           f'is {age_days}d old and price has risen to '
+                           f'${current_price:.2f}. Replacing with stop-limit '
+                           f'on {order_symbol} @ ${stop_price:.2f}'),
+                'cancel_order_id': stale.order_id,
+                'cancel_order': stale,
+                'order': {
+                    'action': 'stop_limit_sell',
+                    'symbol': order_symbol,
+                    'quantity': int(stale.size),
+                    'stop_price': stop_price,
+                    'limit_price': stop_price,
+                    'current_price': current_price,
+                },
+                'paired_buy': {
+                    'action': 'limit_buy',
+                    'symbol': order_symbol,
+                    'quantity': int(stale.size),
+                    'price': buy_price,
+                    'current_price': current_price,
+                }
+            }
 
         if coverage_pct >= self.coverage_threshold * 100:
             return {
@@ -146,6 +182,21 @@ class MomentumDcaStrategy:
             }
         }
 
+    def _find_stale_order(self, current_price, valid_orders):
+        """Find first order older than threshold where price has risen past it."""
+        now = datetime.now()
+        age_threshold = timedelta(hours=self.stale_order_age_hours)
+        ideal_stop = round(current_price * (1 - self.stop_offset_pct), 2)
+
+        for order in valid_orders:
+            if not order.created_at or not order.price:
+                continue
+            if (now - order.created_at) < age_threshold:
+                continue
+            if order.price < ideal_stop:
+                return order
+        return None
+
     def _find_nearest_order(self, current_price, valid_orders):
         """Find the Order entity whose price is closest to current price"""
         best = None
@@ -203,6 +254,14 @@ class MomentumDcaStrategy:
                     pct_away = abs(current_price - o.price) / current_price * 100
                     lines.append(f"    {i}. {o.size:,.4f} units @ ${o.price:,.2f} "
                                  f"({o.order_type.value}) [{pct_away:+.1f}%]")
+        if signal_data['signal'] == 'STALE_REFRESH' and signal_data.get('cancel_order'):
+            cancel = signal_data['cancel_order']
+            lines.append("")
+            lines.append("Stale Order Being Cancelled:")
+            lines.append(f"  Order ID: {cancel.order_id}")
+            lines.append(f"  Size: {int(cancel.size)} shares @ ${cancel.price:,.2f}")
+            age_days = (datetime.now() - cancel.created_at).days if cancel.created_at else '?'
+            lines.append(f"  Age: {age_days} day(s)")
         if signal_data['order']:
             order = signal_data['order']
             lines.append("")

--- a/utils/safe_cash_bot.py
+++ b/utils/safe_cash_bot.py
@@ -555,6 +555,20 @@ class SafeCashBot:
             print(f"{'='*70}\n")
             return None
 
+    def cancel_order(self, order_id, dry_run=True):
+        """Cancel an open order by its Robinhood order ID."""
+        if dry_run:
+            print(f"   [DRY RUN] Would cancel order {order_id}")
+            return True
+
+        try:
+            r.orders.cancel_stock_order(order_id)
+            print(f"   Cancelled order {order_id}")
+            return True
+        except Exception as e:
+            print(f"   Cancel failed for {order_id}: {e}")
+            return False
+
     def get_quote(self, symbol):
         """Get real-time quote"""
         try:


### PR DESCRIPTION
## Summary
- Sell orders older than 24 hours where the stock price has risen past them are automatically cancelled and replaced with new stop-limits at the current price level
- Added `created_at` and `order_id` fields to Order entity, passed through from Robinhood API data
- New `STALE_REFRESH` signal type: cancels the stale order, places a replacement stop-limit sell + paired buy
- Added `cancel_order()` method to SafeCashBot

## Test plan
- [x] 11 new tests: 9 in `TestStaleOrderRefresh`, 2 in `TestLoadBrokerSellOrdersTimestamp`
- [x] All 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)