### PR TITLE
Add historical orders to order-book blob

### DIFF
--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -574,6 +574,8 @@ class TradingSystem:
         if self.strategy_name == 'momentum_dca_long':
             open_orders = self.trading_bot.get_open_orders()
 
+        recent_orders = self.trading_bot.get_recent_orders(days=7)
+
         # Print order book before processing through state manager
         if open_orders:
             # Filter to --ticker symbols when not in verbose mode
@@ -651,6 +653,7 @@ class TradingSystem:
             order_book=open_orders,
             portfolio=portfolio_data,
             drift_metrics=drift_metrics,
+            recent_orders=recent_orders,
         )
 
         # Refresh dashboard market indicators

--- a/trading_system/state/blob_logger.py
+++ b/trading_system/state/blob_logger.py
@@ -29,7 +29,7 @@ def _get_config():
 
 
 def _serialize_state(state_manager, order_book=None, portfolio=None,
-                     drift_metrics=None) -> dict:
+                     drift_metrics=None, recent_orders=None) -> dict:
     """Serialize StateManager state to a JSON-safe dictionary."""
     snapshot = {
         "timestamp": datetime.now().isoformat(),
@@ -45,11 +45,12 @@ def _serialize_state(state_manager, order_book=None, portfolio=None,
         snapshot["order_book"] = order_book
     if portfolio is not None:
         snapshot["portfolio"] = portfolio
-        # Include options from the portfolio if present
         if isinstance(portfolio, dict) and portfolio.get("options"):
             snapshot["options"] = portfolio["options"]
     if drift_metrics is not None:
         snapshot["drift_metrics"] = drift_metrics
+    if recent_orders:
+        snapshot["recent_orders"] = recent_orders
     return snapshot
 
 
@@ -61,11 +62,12 @@ def _serialize_value(obj):
 
 
 def _log_local(state_manager, order_book=None, portfolio=None,
-               drift_metrics=None):
+               drift_metrics=None, recent_orders=None):
     """Write state snapshot to a local JSON file under state_logs/."""
     LOCAL_LOG_DIR.mkdir(exist_ok=True)
     snapshot = _serialize_state(state_manager, order_book=order_book,
-                                portfolio=portfolio, drift_metrics=drift_metrics)
+                                portfolio=portfolio, drift_metrics=drift_metrics,
+                                recent_orders=recent_orders)
     blob_key = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     payload = json.dumps(snapshot, default=_serialize_value, indent=2)
 
@@ -76,7 +78,7 @@ def _log_local(state_manager, order_book=None, portfolio=None,
 
 
 def _log_remote(state_manager, order_book=None, portfolio=None,
-                drift_metrics=None):
+                drift_metrics=None, recent_orders=None):
     """Upload state snapshot to Netlify Blobs."""
     config = _get_config()
     if not config:
@@ -85,7 +87,8 @@ def _log_remote(state_manager, order_book=None, portfolio=None,
         return None
 
     snapshot = _serialize_state(state_manager, order_book=order_book,
-                                portfolio=portfolio, drift_metrics=drift_metrics)
+                                portfolio=portfolio, drift_metrics=drift_metrics,
+                                recent_orders=recent_orders)
     blob_key = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
     payload = json.dumps(snapshot, default=_serialize_value)
 
@@ -106,13 +109,15 @@ def _log_remote(state_manager, order_book=None, portfolio=None,
 
 
 def log_state_to_blob(state_manager, live=False, order_book=None,
-                      portfolio=None, drift_metrics=None):
+                      portfolio=None, drift_metrics=None, recent_orders=None):
     """Log StateManager state. Writes locally in dry-run, uploads to Netlify Blobs when live."""
     if live:
         return _log_remote(state_manager, order_book=order_book,
-                           portfolio=portfolio, drift_metrics=drift_metrics)
+                           portfolio=portfolio, drift_metrics=drift_metrics,
+                           recent_orders=recent_orders)
     return _log_local(state_manager, order_book=order_book,
-                      portfolio=portfolio, drift_metrics=drift_metrics)
+                      portfolio=portfolio, drift_metrics=drift_metrics,
+                      recent_orders=recent_orders)
 
 
 def upload_blob(store_name, blob_key, data):

--- a/utils/safe_cash_bot.py
+++ b/utils/safe_cash_bot.py
@@ -945,6 +945,100 @@ class SafeCashBot:
             print(f"[ERR] Error getting open option orders: {e}")
             return []
 
+    def get_recent_orders(self, days=7):
+        """
+        Get recently filled and cancelled orders for this account.
+
+        Args:
+            days: Number of days of history to fetch (default 7)
+
+        Returns:
+            List of historical orders with same shape as get_open_orders()
+        """
+        try:
+            from datetime import timedelta
+            cutoff = datetime.utcnow() - timedelta(days=days)
+            cutoff_str = cutoff.strftime('%Y-%m-%dT00:00:00Z')
+
+            all_orders = r.orders.get_all_stock_orders(info=None)
+
+            orders = []
+            if not all_orders:
+                return orders
+
+            for order in all_orders:
+                state = order.get('state', '')
+                if state not in ('filled', 'cancelled', 'failed', 'rejected'):
+                    continue
+
+                updated_at_raw = order.get('updated_at', '')
+                if updated_at_raw and updated_at_raw < cutoff_str:
+                    continue
+
+                order_id = order.get('id', 'N/A')
+                symbol = order.get('symbol', 'N/A')
+
+                if symbol == 'N/A':
+                    instrument_id = order.get('instrument_id')
+                    if instrument_id:
+                        try:
+                            instrument = r.stocks.get_instrument_by_url(
+                                f"https://api.robinhood.com/instruments/{instrument_id}/"
+                            )
+                            if instrument:
+                                symbol = instrument.get('symbol', 'N/A')
+                        except Exception:
+                            pass
+
+                side = order.get('side', 'N/A')
+                order_type = order.get('type', 'N/A')
+                trigger = order.get('trigger', 'immediate')
+                quantity = float(order.get('quantity', 0))
+                limit_price = order.get('price')
+                stop_price = order.get('stop_price')
+                average_price = order.get('average_price')
+                cumulative_quantity = order.get('cumulative_quantity')
+                created_at = order.get('created_at', 'N/A')
+                updated_at = order.get('updated_at', 'N/A')
+
+                try:
+                    if created_at != 'N/A':
+                        created_dt = datetime.fromisoformat(created_at.replace('Z', '+00:00'))
+                        created_at = created_dt.strftime('%Y-%m-%d %H:%M:%S')
+                except Exception:
+                    pass
+
+                if trigger == 'stop' and order_type == 'limit':
+                    order_desc = 'Stop Limit'
+                elif trigger == 'stop':
+                    order_desc = 'Stop Loss'
+                elif order_type == 'limit':
+                    order_desc = 'Limit'
+                else:
+                    order_desc = 'Market'
+
+                orders.append({
+                    'order_id': order_id,
+                    'symbol': symbol,
+                    'side': side.upper() if side != 'N/A' else 'N/A',
+                    'order_type': order_desc,
+                    'trigger': trigger,
+                    'state': state,
+                    'quantity': quantity,
+                    'limit_price': float(limit_price) if limit_price else None,
+                    'stop_price': float(stop_price) if stop_price else None,
+                    'average_price': float(average_price) if average_price else None,
+                    'filled_quantity': float(cumulative_quantity) if cumulative_quantity else None,
+                    'created_at': created_at,
+                    'updated_at': updated_at,
+                })
+
+            return orders
+
+        except Exception as e:
+            print(f"❌ Error getting recent orders: {e}")
+            return []
+
     def validate_buy_order(self, symbol, quantity, price):
         """
         Validate a buy order before execution


### PR DESCRIPTION
## Summary
- Adds `get_recent_orders()` method to `SafeCashBot` that fetches filled/cancelled/failed/rejected orders from the last 7 days
- Includes them as `recent_orders` in the blob payload via `log_state_to_blob`
- Companion to OptimChain/allocation-manager#33 which renders historical orders in the dashboard UI

## Changes
- **`utils/safe_cash_bot.py`** — New `get_recent_orders(days=7)` method using the same symbol resolution and order-type mapping logic as `get_open_orders()`
- **`trading_system/main.py`** — Calls `get_recent_orders()` in `run_once()` and passes result to `log_state_to_blob`
- **`trading_system/state/blob_logger.py`** — Threads `recent_orders` through `_serialize_state`, `_log_local`, `_log_remote`, and `log_state_to_blob`

## Test plan
- [ ] Dry-run the trading system and verify `recent_orders` appears in the local JSON state log
- [ ] Confirm the blob payload structure matches what the dashboard UI expects
- [ ] Verify no regressions when `recent_orders` is empty (no historical orders in window)