### PR TITLE
Add Swagger API endpoints on Netlify Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ dmypy.json
 # Backtest cached data and generated charts
 trading_system/backtests/data/
 docs/charts/
+
+# Node.js (Netlify Functions)
+node_modules/
+.netlify/

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,63 @@
+[build]
+  command = "cp -r dashboard public/dashboard"
+  publish = "public"
+  functions = "netlify/functions"
+
+[functions]
+  node_bundler = "esbuild"
+
+# Serve dashboard at root
+[[redirects]]
+  from = "/dashboard"
+  to = "/dashboard/index.html"
+  status = 200
+
+# API redirects to functions
+[[redirects]]
+  from = "/api/health"
+  to = "/.netlify/functions/health"
+  status = 200
+
+[[redirects]]
+  from = "/api/state"
+  to = "/.netlify/functions/state"
+  status = 200
+
+[[redirects]]
+  from = "/api/orders"
+  to = "/.netlify/functions/orders"
+  status = 200
+
+[[redirects]]
+  from = "/api/portfolio"
+  to = "/.netlify/functions/portfolio"
+  status = 200
+
+[[redirects]]
+  from = "/api/market-data"
+  to = "/.netlify/functions/market-data"
+  status = 200
+
+[[redirects]]
+  from = "/api/snapshots"
+  to = "/.netlify/functions/snapshots"
+  status = 200
+
+[[redirects]]
+  from = "/api/snapshots/:key"
+  to = "/.netlify/functions/snapshots?key=:key"
+  status = 200
+
+# Swagger UI
+[[redirects]]
+  from = "/docs"
+  to = "/swagger/index.html"
+  status = 200
+
+[[headers]]
+  for = "/api/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods = "GET, OPTIONS"
+    Access-Control-Allow-Headers = "Content-Type"
+    Content-Type = "application/json"

--- a/netlify/functions/health.js
+++ b/netlify/functions/health.js
@@ -1,0 +1,12 @@
+const { json, options } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  return json({
+    status: "ok",
+    service: "allocation-engine-api",
+    version: "0.1.0",
+    timestamp: new Date().toISOString(),
+  });
+};

--- a/netlify/functions/helpers.js
+++ b/netlify/functions/helpers.js
@@ -1,0 +1,38 @@
+const { getStore } = require("@netlify/blobs");
+
+const STORE_NAME = "order-book";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function json(body, status = 200) {
+  return {
+    statusCode: status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  };
+}
+
+function error(message, status = 500) {
+  return json({ error: message }, status);
+}
+
+function options() {
+  return { statusCode: 204, headers: CORS_HEADERS, body: "" };
+}
+
+async function getLatestSnapshot() {
+  const store = getStore(STORE_NAME);
+  const { blobs } = await store.list();
+  if (!blobs.length) return null;
+  // Keys are ISO timestamps sorted lexicographically — last is newest
+  const sorted = blobs.map((b) => b.key).sort();
+  const latestKey = sorted[sorted.length - 1];
+  const data = await store.get(latestKey, { type: "json" });
+  return { key: latestKey, data };
+}
+
+module.exports = { STORE_NAME, json, error, options, getLatestSnapshot, getStore };

--- a/netlify/functions/market-data.js
+++ b/netlify/functions/market-data.js
@@ -1,0 +1,32 @@
+const { json, error, options, getLatestSnapshot } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  try {
+    const result = await getLatestSnapshot();
+    if (!result) return error("No state snapshots found", 404);
+
+    const { key, data } = result;
+
+    // Extract ticker metrics from state
+    const metrics = {};
+    if (data.tickers) {
+      for (const [symbol, ticker] of Object.entries(data.tickers)) {
+        metrics[symbol] = {
+          order_count: (ticker.orders || []).length,
+          signal_order_count: (ticker.signal_orders || []).length,
+        };
+      }
+    }
+
+    return json({
+      snapshot_key: key,
+      timestamp: data.timestamp,
+      ticker_metrics: metrics,
+      drift_metrics: data.drift_metrics || null,
+    });
+  } catch (e) {
+    return error(`Failed to fetch market data: ${e.message}`);
+  }
+};

--- a/netlify/functions/orders.js
+++ b/netlify/functions/orders.js
@@ -1,0 +1,25 @@
+const { json, error, options, getLatestSnapshot } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  try {
+    const result = await getLatestSnapshot();
+    if (!result) return error("No state snapshots found", 404);
+
+    const { key, data } = result;
+    const orders = data.order_book || [];
+    const optionsList = data.options || [];
+
+    return json({
+      snapshot_key: key,
+      timestamp: data.timestamp,
+      stock_orders: orders,
+      stock_order_count: orders.length,
+      options: optionsList,
+      options_count: optionsList.length,
+    });
+  } catch (e) {
+    return error(`Failed to fetch orders: ${e.message}`);
+  }
+};

--- a/netlify/functions/portfolio.js
+++ b/netlify/functions/portfolio.js
@@ -1,0 +1,19 @@
+const { json, error, options, getLatestSnapshot } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  try {
+    const result = await getLatestSnapshot();
+    if (!result) return error("No state snapshots found", 404);
+
+    const { key, data } = result;
+    return json({
+      snapshot_key: key,
+      timestamp: data.timestamp,
+      portfolio: data.portfolio || null,
+    });
+  } catch (e) {
+    return error(`Failed to fetch portfolio: ${e.message}`);
+  }
+};

--- a/netlify/functions/snapshots.js
+++ b/netlify/functions/snapshots.js
@@ -1,0 +1,29 @@
+const { STORE_NAME, json, error, options, getStore } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  const key = event.queryStringParameters?.key;
+
+  try {
+    const store = getStore(STORE_NAME);
+
+    // If a specific key is requested, return that snapshot
+    if (key) {
+      const data = await store.get(key, { type: "json" });
+      if (!data) return error(`Snapshot '${key}' not found`, 404);
+      return json({ snapshot_key: key, data });
+    }
+
+    // Otherwise list all snapshot keys
+    const { blobs } = await store.list();
+    const keys = blobs.map((b) => b.key).sort().reverse();
+
+    return json({
+      count: keys.length,
+      snapshots: keys.slice(0, 50), // Return most recent 50
+    });
+  } catch (e) {
+    return error(`Failed to fetch snapshots: ${e.message}`);
+  }
+};

--- a/netlify/functions/state.js
+++ b/netlify/functions/state.js
@@ -1,0 +1,21 @@
+const { json, error, options, getLatestSnapshot } = require("./helpers");
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") return options();
+
+  try {
+    const result = await getLatestSnapshot();
+    if (!result) return error("No state snapshots found", 404);
+
+    const { key, data } = result;
+    return json({
+      snapshot_key: key,
+      timestamp: data.timestamp,
+      state: data.state,
+      tickers: data.tickers,
+      drift_metrics: data.drift_metrics || null,
+    });
+  } catch (e) {
+    return error(`Failed to fetch state: ${e.message}`);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "allocation-engine-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "allocation-engine-api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@netlify/blobs": "^8.1.0"
+      }
+    },
+    "node_modules/@netlify/blobs": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-8.2.0.tgz",
+      "integrity": "sha512-9djLZHBKsoKk8XCgwWSEPK9QnT8qqxEQGuYh48gFIcNLvpBKkLnHbDZuyUxmNemCfDz7h0HnMXgSPnnUVgARhg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "allocation-engine-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Swagger API endpoints for allocation engine trading system",
+  "dependencies": {
+    "@netlify/blobs": "^8.1.0"
+  }
+}

--- a/public/swagger/index.html
+++ b/public/swagger/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Allocation Engine API</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css">
+  <style>
+    body { margin: 0; background: #1a1a2e; }
+    #swagger-ui .topbar { display: none; }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: "/swagger/openapi.yaml",
+      dom_id: "#swagger-ui",
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset,
+      ],
+      layout: "BaseLayout",
+    });
+  </script>
+</body>
+</html>

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -1,0 +1,422 @@
+openapi: 3.0.3
+info:
+  title: Allocation Engine API
+  description: |
+    REST API for the allocation engine trading system.
+    Reads state snapshots from Netlify Blobs written by the live trading engine.
+  version: 0.1.0
+  contact:
+    name: Allocation Engine
+
+servers:
+  - url: /api
+    description: Netlify Functions (production)
+
+paths:
+  /health:
+    get:
+      summary: Health check
+      operationId: getHealth
+      tags: [System]
+      responses:
+        "200":
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HealthResponse"
+
+  /state:
+    get:
+      summary: Latest trading state
+      description: Returns the most recent state snapshot including tickers, strategy state, and drift metrics.
+      operationId: getState
+      tags: [Trading]
+      responses:
+        "200":
+          description: Current trading state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StateResponse"
+        "404":
+          description: No state snapshots found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /orders:
+    get:
+      summary: Open orders
+      description: Returns all open stock orders and active options positions from the latest snapshot.
+      operationId: getOrders
+      tags: [Trading]
+      responses:
+        "200":
+          description: Current open orders
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OrdersResponse"
+        "404":
+          description: No state snapshots found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /portfolio:
+    get:
+      summary: Portfolio snapshot
+      description: Returns the portfolio holdings from the latest state snapshot.
+      operationId: getPortfolio
+      tags: [Trading]
+      responses:
+        "200":
+          description: Current portfolio
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PortfolioResponse"
+        "404":
+          description: No state snapshots found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /market-data:
+    get:
+      summary: Market data and metrics
+      description: Returns ticker-level metrics and drift analysis from the latest snapshot.
+      operationId: getMarketData
+      tags: [Market Data]
+      responses:
+        "200":
+          description: Market data and metrics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MarketDataResponse"
+        "404":
+          description: No state snapshots found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /snapshots:
+    get:
+      summary: List state snapshots
+      description: Returns the most recent 50 snapshot keys, sorted newest first.
+      operationId: listSnapshots
+      tags: [Snapshots]
+      responses:
+        "200":
+          description: List of snapshot keys
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotListResponse"
+
+  /snapshots/{key}:
+    get:
+      summary: Get a specific snapshot
+      description: Returns the full data for a specific snapshot by its timestamp key.
+      operationId: getSnapshot
+      tags: [Snapshots]
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: "Snapshot timestamp key (e.g. 2025-02-23T14-30-00)"
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Snapshot data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SnapshotResponse"
+        "404":
+          description: Snapshot not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+      required: [error]
+
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+        service:
+          type: string
+          example: allocation-engine-api
+        version:
+          type: string
+          example: 0.1.0
+        timestamp:
+          type: string
+          format: date-time
+
+    StockOrder:
+      type: object
+      properties:
+        symbol:
+          type: string
+          example: BTC
+        side:
+          type: string
+          enum: [BUY, SELL]
+        quantity:
+          type: number
+          example: 250
+        order_type:
+          type: string
+          example: limit
+        limit_price:
+          type: number
+          nullable: true
+          example: 95000.50
+        stop_price:
+          type: number
+          nullable: true
+
+    OptionPosition:
+      type: object
+      properties:
+        chain_symbol:
+          type: string
+          example: QQQ
+        strike:
+          type: number
+          example: 500
+        option_type:
+          type: string
+          enum: [call, put]
+        expiration:
+          type: string
+          example: "2025-03-21"
+        quantity:
+          type: number
+        position_type:
+          type: string
+          enum: [long, short]
+        mark_price:
+          type: number
+          nullable: true
+        avg_price:
+          type: number
+        current_value:
+          type: number
+        unrealized_pl:
+          type: number
+        unrealized_pl_pct:
+          type: number
+        dte:
+          type: integer
+          nullable: true
+        underlying_price:
+          type: number
+          nullable: true
+        greeks:
+          type: object
+          properties:
+            delta:
+              type: number
+              nullable: true
+            gamma:
+              type: number
+              nullable: true
+            theta:
+              type: number
+              nullable: true
+            vega:
+              type: number
+              nullable: true
+            iv:
+              type: number
+              nullable: true
+        recommended_action:
+          type: object
+          properties:
+            action:
+              type: string
+              enum: [HOLD, CLOSE]
+            reasons:
+              type: array
+              items:
+                type: string
+
+    TickerState:
+      type: object
+      properties:
+        orders:
+          type: array
+          items:
+            type: object
+            description: Order state from the trading engine
+        signal_orders:
+          type: array
+          items:
+            type: object
+            description: Signal-triggered orders
+
+    DriftMetrics:
+      type: object
+      properties:
+        rolling_sharpe:
+          type: number
+          example: 0.42
+        rolling_vol_pct:
+          type: number
+          example: 24.5
+        rolling_return_pct:
+          type: number
+          example: 1.23
+        regime:
+          type: string
+          enum: [LOW_VOL, MEDIUM_VOL, HIGH_VOL]
+        regime_rationale:
+          type: string
+        window_days:
+          type: integer
+          example: 21
+        as_of:
+          type: string
+        suggested_params:
+          type: object
+          properties:
+            stop_offset_pct:
+              type: number
+            buy_offset:
+              type: number
+            coverage_threshold:
+              type: number
+        grid_sharpe:
+          type: number
+          nullable: true
+        mean_test_sharpe:
+          type: number
+          nullable: true
+        degradation:
+          type: number
+          nullable: true
+        drift_alerts:
+          type: array
+          items:
+            type: object
+            properties:
+              metric:
+                type: string
+              value:
+                type: number
+              threshold:
+                type: number
+
+    StateResponse:
+      type: object
+      properties:
+        snapshot_key:
+          type: string
+          example: "2025-02-23T14-30-00"
+        timestamp:
+          type: string
+          format: date-time
+        state:
+          type: object
+          description: Raw strategy state
+        tickers:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TickerState"
+        drift_metrics:
+          $ref: "#/components/schemas/DriftMetrics"
+
+    OrdersResponse:
+      type: object
+      properties:
+        snapshot_key:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        stock_orders:
+          type: array
+          items:
+            $ref: "#/components/schemas/StockOrder"
+        stock_order_count:
+          type: integer
+        options:
+          type: array
+          items:
+            $ref: "#/components/schemas/OptionPosition"
+        options_count:
+          type: integer
+
+    PortfolioResponse:
+      type: object
+      properties:
+        snapshot_key:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        portfolio:
+          type: object
+          nullable: true
+          description: Portfolio holdings and positions
+
+    MarketDataResponse:
+      type: object
+      properties:
+        snapshot_key:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        ticker_metrics:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              order_count:
+                type: integer
+              signal_order_count:
+                type: integer
+        drift_metrics:
+          $ref: "#/components/schemas/DriftMetrics"
+
+    SnapshotListResponse:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 42
+        snapshots:
+          type: array
+          items:
+            type: string
+          description: Snapshot keys (most recent 50), newest first
+
+    SnapshotResponse:
+      type: object
+      properties:
+        snapshot_key:
+          type: string
+        data:
+          type: object
+          description: Full snapshot data


### PR DESCRIPTION
## Summary

Setup swagger

Add REST API with 7 endpoints that read from the existing Netlify Blobs store:
- `/api/health` — Health check
- `/api/state` — Latest trading state & drift metrics
- `/api/orders` — Open stock orders + active options
- `/api/portfolio` — Portfolio holdings
- `/api/market-data` — Ticker metrics
- `/api/snapshots` — List/fetch state snapshots

Includes OpenAPI 3.0 spec and Swagger UI at `/docs`. Functions integrate seamlessly with the live trading engine's state snapshots via `@netlify/blobs`.

## Testing

python -m pytest tests/ -q 2>&1 | tail -20