### PR TITLE
Index machine-generated orders in the order book

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -89,6 +89,7 @@
     .ob-row .ob-price { color: #ccc; font-variant-numeric: tabular-nums; }
     .ob-row.buy .ob-side { color: #4a4; }
     .ob-row.sell .ob-side { color: #a44; }
+    .ob-row .ob-idx { font-size: 8px; color: #000; background: #5a5; border-radius: 2px; padding: 0 4px; font-weight: 600; min-width: 14px; text-align: center; }
     .ob-empty { color: #333; font-size: 10px; padding: 12px 0; text-align: center; }
 
     /* Options cards */
@@ -447,17 +448,20 @@ function renderBook() {
   let html = '';
 
   // ── Stock Orders ──
-  html += '<div class="book-section-title">Stock Orders (' + orders.length + ')</div>';
+  const machineCount = orders.filter(o => o.source === 'engine').length;
+  html += '<div class="book-section-title">Stock Orders (' + orders.length + (machineCount ? ' · ' + machineCount + ' engine' : '') + ')</div>';
   if (orders.length) {
     const buys = orders.filter(o => o.side === 'BUY');
     const sells = orders.filter(o => o.side === 'SELL');
     for (const o of buys) {
       const price = o.limit_price ? '$'+o.limit_price.toFixed(2) : (o.stop_price ? 'stop $'+o.stop_price.toFixed(2) : 'MKT');
-      html += `<div class="ob-row buy"><span class="ob-sym">${o.symbol}</span><span class="ob-side">BUY</span><span class="ob-qty">${o.quantity.toFixed(0)}</span><span class="ob-type">${o.order_type}</span><span class="ob-price">${price}</span></div>`;
+      const idx = o.machine_index ? `<span class="ob-idx">#${o.machine_index}</span>` : '';
+      html += `<div class="ob-row buy">${idx}<span class="ob-sym">${o.symbol}</span><span class="ob-side">BUY</span><span class="ob-qty">${o.quantity.toFixed(0)}</span><span class="ob-type">${o.order_type}</span><span class="ob-price">${price}</span></div>`;
     }
     for (const o of sells) {
       const price = o.limit_price ? '$'+o.limit_price.toFixed(2) : (o.stop_price ? 'stop $'+o.stop_price.toFixed(2) : 'MKT');
-      html += `<div class="ob-row sell"><span class="ob-sym">${o.symbol}</span><span class="ob-side">SELL</span><span class="ob-qty">${o.quantity.toFixed(0)}</span><span class="ob-type">${o.order_type}</span><span class="ob-price">${price}</span></div>`;
+      const idx = o.machine_index ? `<span class="ob-idx">#${o.machine_index}</span>` : '';
+      html += `<div class="ob-row sell">${idx}<span class="ob-sym">${o.symbol}</span><span class="ob-side">SELL</span><span class="ob-qty">${o.quantity.toFixed(0)}</span><span class="ob-type">${o.order_type}</span><span class="ob-price">${price}</span></div>`;
     }
   } else {
     html += '<div class="ob-empty">No open stock orders</div>';

--- a/public/swagger/openapi.yaml
+++ b/public/swagger/openapi.yaml
@@ -175,6 +175,10 @@ components:
     StockOrder:
       type: object
       properties:
+        order_id:
+          type: string
+          description: Robinhood order UUID
+          example: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
         symbol:
           type: string
           example: BTC
@@ -194,6 +198,20 @@ components:
         stop_price:
           type: number
           nullable: true
+        source:
+          type: string
+          enum: [engine, external]
+          description: Whether this order was placed by the trading engine or externally (e.g. via Robinhood UI)
+          example: engine
+        machine_index:
+          type: integer
+          nullable: true
+          description: Sequential index for engine-generated orders (null for external orders)
+          example: 1
+        created_at:
+          type: string
+          description: Order creation timestamp
+          example: "2025-02-23 14:30:00"
 
     OptionPosition:
       type: object
@@ -360,6 +378,9 @@ components:
             $ref: "#/components/schemas/StockOrder"
         stock_order_count:
           type: integer
+        machine_order_count:
+          type: integer
+          description: Number of orders placed by the trading engine
         options:
           type: array
           items:

--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -662,7 +662,23 @@ class TradingSystem:
                 extra = {}
                 if portfolio_data and isinstance(portfolio_data, dict):
                     extra['options'] = portfolio_data.get('options', [])
-                    extra['order_book'] = portfolio_data.get('open_orders', [])
+                    # Tag orders with source: engine vs external
+                    signal_ids = set()
+                    for ticker in self.state_manager.tickers.values():
+                        for o in ticker.get_signal_orders():
+                            if o.order_id:
+                                signal_ids.add(o.order_id)
+                    ob = portfolio_data.get('open_orders', [])
+                    idx = 1
+                    for o in ob:
+                        if o.get('order_id') in signal_ids:
+                            o['source'] = 'engine'
+                            o['machine_index'] = idx
+                            idx += 1
+                        else:
+                            o['source'] = 'external'
+                            o['machine_index'] = None
+                    extra['order_book'] = ob
                 fetch_and_write_indicators(self.symbols, extra_data=extra)
             except Exception as e:
                 print(f"  [indicators] Error refreshing dashboard: {e}")

--- a/trading_system/state/blob_logger.py
+++ b/trading_system/state/blob_logger.py
@@ -36,12 +36,26 @@ def _serialize_state(state_manager, order_book=None, portfolio=None,
         "state": state_manager.state,
         "tickers": {},
     }
+    signal_ids = set()
     for symbol, ticker in state_manager.tickers.items():
+        signal = ticker.get_signal_orders()
         snapshot["tickers"][symbol] = {
             "orders": [order.get_state() for order in ticker.orders],
-            "signal_orders": [order.get_state() for order in ticker.get_signal_orders()],
+            "signal_orders": [order.get_state() for order in signal],
         }
+        for o in signal:
+            if o.order_id:
+                signal_ids.add(o.order_id)
     if order_book is not None:
+        idx = 1
+        for o in order_book:
+            if o.get('order_id') in signal_ids:
+                o['source'] = 'engine'
+                o['machine_index'] = idx
+                idx += 1
+            else:
+                o['source'] = 'external'
+                o['machine_index'] = None
         snapshot["order_book"] = order_book
     if portfolio is not None:
         snapshot["portfolio"] = portfolio


### PR DESCRIPTION
## Summary
- Cross-references signal order IDs from the state manager against the full Robinhood order book to distinguish engine-placed orders from manually-placed ones
- Tags each order with `source` (`engine`/`external`) and a sequential `machine_index` in both the blob snapshot (API) and dashboard data
- Adds `order_id`, `source`, `machine_index`, and `created_at` fields to the OpenAPI `StockOrder` schema; adds `machine_order_count` to `OrdersResponse`
- Renders green `#N` index badges on engine orders in the dashboard, with an engine count in the section header

## Test plan
- [x] All 114 existing tests pass
- [ ] Run live with `--dashboard` and verify engine orders show green badges, manual orders do not
- [ ] Verify `/api/orders` response includes `source` and `machine_index` fields
- [ ] Confirm Swagger UI reflects updated `StockOrder` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)