### PR TITLE
Add debug logging to blob uploads

### DIFF
--- a/trading_system/state/blob_logger.py
+++ b/trading_system/state/blob_logger.py
@@ -98,13 +98,26 @@ def _log_remote(state_manager, order_book=None, portfolio=None,
         "Content-Type": "application/json",
     }
 
+    # Debug: print what we're sending
+    print(f"\n  [blob] PUT {STORE_NAME}/{blob_key}")
+    print(f"  [blob] Payload keys: {list(snapshot.keys())}")
+    print(f"  [blob] Payload size: {len(payload)} bytes")
+    print(f"  [blob] Tickers: {list(snapshot.get('tickers', {}).keys())}")
+    print(f"  [blob] Order book entries: {len(snapshot.get('order_book', []))}")
+    print(f"  [blob] Recent orders: {len(snapshot.get('recent_orders', []))}")
+    if snapshot.get('drift_metrics'):
+        print(f"  [blob] Drift metrics symbols: {list(snapshot['drift_metrics'].keys())}")
+
     try:
         resp = requests.put(url, headers=headers, data=payload, timeout=10)
+        print(f"  [blob] Response: {resp.status_code} {resp.reason}")
+        if resp.text:
+            print(f"  [blob] Response body: {resp.text[:500]}")
         resp.raise_for_status()
-        print(f"State logged to Netlify Blobs: {STORE_NAME}/{blob_key}")
+        print(f"  [blob] State logged to Netlify Blobs: {STORE_NAME}/{blob_key}")
         return blob_key
     except requests.RequestException as e:
-        print(f"Failed to log state to Netlify Blobs: {e}")
+        print(f"  [blob] FAILED: {e}")
         return None
 
 
@@ -136,11 +149,18 @@ def upload_blob(store_name, blob_key, data):
         "Content-Type": "application/json",
     }
 
+    # Debug: print what we're sending
+    print(f"\n  [blob] PUT {store_name}/{blob_key}")
+    print(f"  [blob] Payload size: {len(payload)} bytes")
+
     try:
         resp = requests.put(url, headers=headers, data=payload, timeout=15)
+        print(f"  [blob] Response: {resp.status_code} {resp.reason}")
+        if resp.text:
+            print(f"  [blob] Response body: {resp.text[:500]}")
         resp.raise_for_status()
-        print(f"  Blob uploaded: {store_name}/{blob_key}")
+        print(f"  [blob] Uploaded: {store_name}/{blob_key}")
         return blob_key
     except requests.RequestException as e:
-        print(f"  Failed to upload blob {store_name}/{blob_key}: {e}")
+        print(f"  [blob] FAILED {store_name}/{blob_key}: {e}")
         return None


### PR DESCRIPTION
## Summary
- Print payload metadata (keys, size, tickers, order/recent order counts, drift metrics symbols) before each Netlify blob upload
- Log full Netlify response (status code, reason, body) for both `_log_remote` and `upload_blob`
- Consistent `[blob]` prefix on all log lines for easy grep filtering

## Test plan
- [x] Verified dry-run still logs locally (no `[blob]` output)
- [x] Verified live run prints payload summary and `201 Created` response
- [x] Confirmed blob exists on Netlify via API list

🤖 Generated with [Claude Code](https://claude.com/claude-code)