### PR TITLE
Enrich equity positions with name, day change, P/E, and allocation

### DIFF
--- a/utils/safe_cash_bot.py
+++ b/utils/safe_cash_bot.py
@@ -435,12 +435,18 @@ class SafeCashBot:
 
                         positions.append({
                             'symbol': symbol,
+                            'name': data.get('name', ''),
+                            'type': data.get('type', ''),
                             'quantity': quantity,
                             'avg_buy_price': avg_price,
                             'current_price': current_price,
                             'equity': equity,
                             'profit_loss': profit_loss,
-                            'profit_loss_pct': profit_loss_pct
+                            'profit_loss_pct': profit_loss_pct,
+                            'percent_change': self._safe_float(data.get('percent_change')),
+                            'equity_change': self._safe_float(data.get('equity_change')),
+                            'pe_ratio': self._safe_float(data.get('pe_ratio')),
+                            'percentage': self._safe_float(data.get('percentage')),
                         })
 
             return positions


### PR DESCRIPTION
## Summary
- Capture additional fields from Robinhood's `build_holdings()` in `get_positions()` that were previously discarded
- New fields: `name`, `type`, `percent_change`, `equity_change`, `pe_ratio`, `percentage` (portfolio allocation)
- These flow into the Netlify Blob snapshot automatically for richer frontend display

## Test plan
- [ ] Run trading system and verify positions in the blob include the new fields
- [ ] Confirm no errors when fields return None (uses `_safe_float` for numeric fields)