### PR TITLE
Fix archive-blobs workflow script path

### DIFF
--- a/.github/workflows/archive-blobs.yml
+++ b/.github/workflows/archive-blobs.yml
@@ -24,4 +24,4 @@ jobs:
           NETLIFY_API_TOKEN: ${{ secrets.NETLIFY_API_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           RETENTION_DAYS: '7'
-        run: python tunis/scripts/archive_old_blobs.py
+        run: python scripts/archive_old_blobs.py


### PR DESCRIPTION
## Summary
- The `archive-blobs.yml` workflow referenced `tunis/scripts/archive_old_blobs.py` which doesn't exist — the script lives at `scripts/archive_old_blobs.py`
- Fixed the path so the scheduled and manual workflow runs succeed

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and confirm it completes without `No such file` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)