### PR TITLE
Use state-logs blob store for state uploads

### DIFF
--- a/trading_system/state/blob_logger.py
+++ b/trading_system/state/blob_logger.py
@@ -15,7 +15,7 @@ import requests
 
 
 NETLIFY_BLOBS_URL = "https://api.netlify.com/api/v1/blobs"
-STORE_NAME = "order-book"
+STORE_NAME = "state-logs"  # Using state-logs while UI manages cut-overs
 LOCAL_LOG_DIR = Path(__file__).resolve().parent.parent.parent / "state_logs"
 
 


### PR DESCRIPTION
## Summary

Switching UI to [render](https://render.com/) based backend. Having local client point to state-logs for now while we work through local testing. 