### PR TITLE
Guard _send_oncall_summary against None trading_bot

### DIFF
--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -862,7 +862,7 @@ class TradingSystem:
             lines.append("=" * 40)
 
             # PDT status
-            pdt_info = self.trading_bot.get_pdt_status()
+            pdt_info = self.trading_bot.get_pdt_status() if self.trading_bot else None
             if pdt_info is not None:
                 count = pdt_info.get('day_trade_count', 0)
                 if pdt_info.get('flagged'):


### PR DESCRIPTION
## Summary
- Fixes `'NoneType' object has no attribute 'get_pdt_status'` printed every cycle on the Render headless worker (logs at srv-d70trd15pdvs739ic1dg).
- In publish-only mode (commit 3948fb0), `self.trading_bot` is intentionally `None` when RH creds are absent, but `_send_oncall_summary` still called `.get_pdt_status()` on it.
- The existing `else: lines.append("PDT: unavailable")` branch already handles `None`, so the fix is a single ternary guard.

## Note on netlify
Netlify auth is fine — the blob upload before the crash returned `201 Created`. The error in the logs was the unrelated downstream Slack-summary path.

## Test plan
- [x] `pytest -q` — no new failures introduced (7 pre-existing failures on the base branch are unrelated and present without this change).
- [ ] Verify on Render after merge that `[oncall] Error sending Slack summary` no longer appears and the Slack summary message arrives with `PDT: unavailable`.