### PR TITLE
Guard _send_oncall_summary against None trading_bot (prod branch)

### DIFF
--- a/trading_system/main.py
+++ b/trading_system/main.py
@@ -870,7 +870,7 @@ class TradingSystem:
             lines.append("=" * 40)
 
             # PDT status
-            pdt_info = self.trading_bot.get_pdt_status()
+            pdt_info = self.trading_bot.get_pdt_status() if self.trading_bot else None
             if pdt_info is not None:
                 count = pdt_info.get('day_trade_count', 0)
                 if pdt_info.get('flagged'):


### PR DESCRIPTION
## Summary
- Same fix as #57, ported onto `IamJasonBian/render-prod-dry-run` — the branch that the Render worker `srv-d70trd15pdvs739ic1dg` actually tracks.
- #57 went into `-v1` by mistake.

## Test plan
- [ ] Merge, then trigger a manual Render deploy (autoDeploy is off on this service).
- [ ] Confirm `[oncall] Error sending Slack summary` no longer appears in logs and the Slack summary posts with `PDT: unavailable`.